### PR TITLE
Collect test coverage statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,8 @@ install:
   - pip install lmdb
   - pip install plyvel
   - pip install pyrocksdb
+  - pip install pytest-cov
+  - pip install python-coveralls
 # command to run tests
-script: pytest
+script: pytest --cov=server --cov=lib
+after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 .. image:: https://travis-ci.org/kyuupichan/electrumx.svg?branch=master
     :target: https://travis-ci.org/kyuupichan/electrumx
+.. image:: https://coveralls.io/repos/github/kyuupichan/electrumx/badge.svg
+    :target: https://coveralls.io/github/kyuupichan/electrumx
+
 
 ElectrumX - Reimplementation of Electrum-server
 ===============================================


### PR DESCRIPTION
This makes the CI build generate helpful statistics about the test coverage ([like this one](https://coveralls.io/builds/8712003#DataTables_Table_0_wrapper) 📊 ).

Might be useful to determine which modules still need unit tests.

If you want to merge this you will also need to login on [coveralls.io](https://coveralls.io/sign-up) and activate the repo there.