### PR TITLE
Update for DASH

### DIFF
--- a/docs/HOWTO.rst
+++ b/docs/HOWTO.rst
@@ -14,7 +14,8 @@ small - patches welcome.
 + irc:      Python IRC package.  Only required if you enable IRC; ElectrumX
             will happily serve clients that try to connect directly.
             I use 15.0.4 but older versions likely are fine.
-
++ x11_hash: Python X11 Hash package. Only required if you use ElectrumX
+            with Dash Network (Both Mainnet and Testnet). Version == 1.4 ;
 
 While not requirements for running ElectrumX, it is intended to be run
 with supervisor software such as Daniel Bernstein's daemontools,

--- a/lib/coins.py
+++ b/lib/coins.py
@@ -177,6 +177,9 @@ class Coin(object):
     @classmethod
     def header_hashes(cls, header):
         '''Given a header return the previous and current block hashes.'''
+        if cls.NAME.lower() == 'dash':
+            import x11_hash
+            return header[4:36], x11_hash.getPoWHash(header)
         return header[4:36], double_sha256(header)
 
     @classmethod
@@ -307,24 +310,36 @@ class DogecoinTestnet(Coin):
     WIF_BYTE = 0xf1
 
 
-# Source: pycoin
+# Source: https://github.com/dashpay/dash
 class Dash(Coin):
     NAME = "Dash"
     SHORTNAME = "DASH"
     NET = "mainnet"
     XPUB_VERBYTES = bytes.fromhex("02fe52cc")
     XPRV_VERBYTES = bytes.fromhex("02fe52f8")
+    GENESIS_HASH = (b'00000ffd590b1485b3caadc19b22e637'
+                    b'9c733355108f107a430458cdf3407ab6')
     P2PKH_VERBYTE = 0x4c
     P2SH_VERBYTE = 0x10
     WIF_BYTE = 0xcc
+    TX_COUNT_HEIGHT = 569399
+    TX_COUNT = 2157510
+    TX_PER_BLOCK = 4
 
 
 class DashTestnet(Coin):
-    NAME = "Dogecoin"
+    NAME = "Dash"
     SHORTNAME = "tDASH"
     NET = "testnet"
     XPUB_VERBYTES = bytes.fromhex("3a805837")
     XPRV_VERBYTES = bytes.fromhex("3a8061a0")
-    P2PKH_VERBYTE = 0x8b
+    GENESIS_HASH = (b'00000bafbc94add76cb75e2ec9289483'
+                    b'7288a481e5c005f6563d91623bf8bc2c')
+    P2PKH_VERBYTE = 0x8c
     P2SH_VERBYTE = 0x13
     WIF_BYTE = 0xef
+    TX_COUNT_HEIGHT = 101619
+    TX_COUNT = 132681
+    TX_PER_BLOCK = 1
+
+#

--- a/lib/coins.py
+++ b/lib/coins.py
@@ -177,9 +177,6 @@ class Coin(object):
     @classmethod
     def header_hashes(cls, header):
         '''Given a header return the previous and current block hashes.'''
-        if cls.NAME.lower() == 'dash':
-            import x11_hash
-            return header[4:36], x11_hash.getPoWHash(header)
         return header[4:36], double_sha256(header)
 
     @classmethod
@@ -326,8 +323,13 @@ class Dash(Coin):
     TX_COUNT = 2157510
     TX_PER_BLOCK = 4
 
+    @classmethod
+    def header_hashes(cls, header):
+        '''Given a header return the previous and current block hashes.'''
+        import x11_hash
+        return header[4:36], x11_hash.getPoWHash(header)
 
-class DashTestnet(Coin):
+class DashTestnet(Dash):
     NAME = "Dash"
     SHORTNAME = "tDASH"
     NET = "testnet"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     python_requires='>=3.5',
     # "irc" package is only required if IRC connectivity is enabled
     # via environment variables, in which case I've tested with 15.0.4
+    # "x11_hash" package (1.4) is required to sync DASH network.
     install_requires=['plyvel', 'aiohttp >= 1'],
     packages=setuptools.find_packages(),
     description='ElectrumX Server',


### PR DESCRIPTION
- Update information for both mainnet and testnet
- Use x11_hash module when network name is Dash to process header_hashes