### PR TITLE
Add optional option to anonymise logs (remove IP addresses)

### DIFF
--- a/samples/scripts/NOTES
+++ b/samples/scripts/NOTES
@@ -33,6 +33,7 @@ RPC_PORT      - Listen on this port for local RPC connections, defaults to
 BANNER_FILE   - a path to a banner file to serve to clients.  The banner file
                 is re-read for each new client.
 DONATION_ADDRESS  - server donation address.  Defaults to none.
+ANON_LOGS - set to remove IP addresses from logs. Default: disabled
 
 If you want IRC connectivity to advertise your node:
 

--- a/server/env.py
+++ b/server/env.py
@@ -40,6 +40,7 @@ class Env(LoggedClass):
         self.rpc_port = self.integer('RPC_PORT', 8000)
         self.max_subscriptions = self.integer('MAX_SUBSCRIPTIONS', 10000)
         self.banner_file = self.default('BANNER_FILE', None)
+        self.anon_logs = self.default('ANON_LOGS', False)
         # The electrum client takes the empty string as unspecified
         self.donation_address = self.default('DONATION_ADDRESS', '')
         self.db_engine = self.default('DB_ENGINE', 'leveldb')

--- a/server/protocol.py
+++ b/server/protocol.py
@@ -202,7 +202,7 @@ class Session(JSONRPC):
     def connection_made(self, transport):
         '''Handle an incoming client connection.'''
         super().connection_made(transport)
-        self.logger.info('connection from {}'.format(self.peername()))
+        self.logger.info('connection from {}'.format(self.peername(True)))
         self.manager.add_session(self)
 
     def connection_lost(self, exc):
@@ -211,7 +211,7 @@ class Session(JSONRPC):
         if self.error_count or self.send_size >= 250000:
             self.logger.info('{} disconnected.  '
                              'Sent {:,d} bytes in {:,d} messages {:,d} errors'
-                             .format(self.peername(), self.send_size,
+                             .format(self.peername(True), self.send_size,
                                      self.send_count, self.error_count))
         self.manager.remove_session(self)
 
@@ -223,8 +223,12 @@ class Session(JSONRPC):
         '''Queue the request for asynchronous handling.'''
         self.manager.add_task(self, self.handle_json_request(request))
 
-    def peername(self):
-        info = self.peer_info
+    def peername(self, for_log=False):
+        # Anonymi{z, s}e all IP addresses that will be stored in a log
+        if for_log and self.env.anon_logs and self.peer_info:
+            info = ["XX.XX.XX.XX", "XX"]
+        else:
+            info = self.peer_info
         return 'unknown' if not info else '{}:{}'.format(info[0], info[1])
 
     def tx_hash_from_param(self, param):


### PR DESCRIPTION
This will replace IP addresses reported when connecting or disconnecting with the string `XX.XX.XX.XX`.

Session.peername gets a new parameter called `for_log` that should be True whenever the return value is intended to be stored in a log file.

This doesn't affect the RPC call `sessions`, IP addresses will still be shown there.

Closes #20