### PR TITLE
Add IRC_PREFIX,IRC_CHANNEL,IRC_SERVER,IRC_PORT

### DIFF
--- a/docs/ENV-NOTES
+++ b/docs/ENV-NOTES
@@ -52,8 +52,12 @@ MAX_SESSION_SUBS - maximum number of address subscriptions permitted to a
 If you want IRC connectivity to advertise your node:
 
 IRC             - set to anything non-empty
+IRC_PREFIX      - The default is 'E'.
 IRC_NICK        - the nick to use when connecting to IRC.  The default is a
-                  hash of REPORT_HOST.  Either way 'E_' will be prepended.
+                  hash of REPORT_HOST. Either way IRC_PREFIX_ will be prepended.
+IRC_CHANNEL     - The default is 'electrum'.
+IRC_SERVER      - The default is 'irc.freenode.net'.
+IRC_PORT        - The default is 6667.
 REPORT_HOST     - the host to advertise.  Defaults to HOST.
 REPORT_SSL_PORT - the SSL port to advertise.  Defaults to SSL_PORT.
 REPORT_TCP_PORT - the TCP port to advertise.  Defaults to TCP_PORT.

--- a/server/env.py
+++ b/server/env.py
@@ -53,7 +53,11 @@ class Env(LoggedClass):
         self.report_tcp_port = self.integer('REPORT_TCP_PORT', self.tcp_port)
         self.report_ssl_port = self.integer('REPORT_SSL_PORT', self.ssl_port)
         self.report_host = self.default('REPORT_HOST', self.host)
+        self.irc_prefix = self.default('IRC_PREFIX', 'E')
         self.irc_nick = self.default('IRC_NICK', None)
+        self.irc_channel = self.default('IRC_CHANNEL', 'electrum')
+        self.irc_server = self.default('IRC_SERVER', 'irc.freenode.net')
+        self.irc_port = self.default('IRC_PORT', 6667)
         self.irc = self.default('IRC', False)
 
     def default(self, envvar, default):


### PR DESCRIPTION
This should allow setting up electrum server for other Coin to find peers on other places.
For example, electrum server for DASH should join #electrum-dash with prefix 'D' for Mainnet and 'd' for Testnet.