### PR TITLE
Serve batch responses directly, without buffering

### DIFF
--- a/electrumx_rpc.py
+++ b/electrumx_rpc.py
@@ -58,7 +58,7 @@ def main():
     args = parser.parse_args()
 
     if args.port is None:
-        args.port = int(environ.get('ELECTRUMX_RPC_PORT', 8000))
+        args.port = int(environ.get('RPC_PORT', 8000))
 
     loop = asyncio.get_event_loop()
     coro = loop.create_connection(RPCClient, 'localhost', args.port)


### PR DESCRIPTION
Currently responses to a batch request are buffered in a list and then flushed out to client when the last request handler is finished.

This changes the behaviour to immediately send the response to the client, constructing the array on the wire.

This might be in violation to **6)** of the [JSONRPC specification](http://www.jsonrpc.org/specification), specifically

> The Server should respond with an Array containing the corresponding Response objects, **after all of the batch Request objects have been processed.** 

However, as the client can't tell the difference anyway, it speeds up response times and reduces memory usage, that's probably not important.