### PR TITLE
Tweak systemd unit file settings

### DIFF
--- a/samples/systemd/electrumx.service
+++ b/samples/systemd/electrumx.service
@@ -6,6 +6,8 @@ After=network.target
 EnvironmentFile=/etc/electrumx.conf
 ExecStart=/usr/local/bin/electrumx_server.py
 User=electrumx
+LimitNOFILE=8192
+TimeoutStopSec=30min
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Set the open file limit to 8192, which should hopefully be enough
- Set the timeout for process termination to 30 minutes. Systemd will send another SIGTERM after 30 minutes and then a SIGKILL after 60 minutes. That should be plenty of time for electrumx to cleanly finish whatever it's doing