### PR TITLE
remove error variable from normal replies in JSONRPCv1 protocol

### DIFF
--- a/lib/jsonrpc.py
+++ b/lib/jsonrpc.py
@@ -61,7 +61,7 @@ class JSONRPCv1(JSONRPC):
     @classmethod
     def response_payload(cls, result, id_):
         '''JSON v1 response payload.  error is present and None.'''
-        return {'id': id_, 'result': result, 'error': None}
+        return {'id': id_, 'result': result}
 
     @classmethod
     def error_payload(cls, message, code, id_):


### PR DESCRIPTION
Even if no error occurred, the server adds an "error":null variable to normal replies.

This change was introduced on commit 06c8eda161a2ae6795bacea92e26977a9c37bd79