### PR TITLE
Minimize default systemd config file

### DIFF
--- a/samples/systemd/electrumx.conf
+++ b/samples/systemd/electrumx.conf
@@ -1,67 +1,9 @@
-#suggested /etc/electrumx.conf for systemd
+# default /etc/electrumx.conf for systemd
 
-#
-#REQUIRED
-#
+# REQUIRED
+DB_DIRECTORY = /db
+# Bitcoin Node RPC Credentials
+DAEMON_URL = http://username:password@hostname:port/
 
-    DB_DIRECTORY =
-    USERNAME = electrumx
-    ELECTRUMX = /usr/local/bin/electrumx_server.py
-
-    #Bitcoin Node RPC Credentials
-    DAEMON_URL = http://username:password@hostname:port/
-        #port is optional, defaults to COIN RPC default
-
-#
-#REQUIRED FOR PUBLIC VISIBILITY
-#
-
-    #HOST = 0.0.0.0
-        #listen on interface, (0.0.0.0 is any)
-    #TCP_PORT = 50001
-    #SSL_PORT = 50002
-        #Requires
-        #SSL_CERTFILE = /path/to/server.crt
-        #SSL_KEYFILE = /path/to/server.key
-
-#
-#OPTIONAL VISIBILITY
-#
-
-    #BANNER_FILE = /path/to/banner
-    #DONATION_ADDRESS =
-    #IRC = yes
-    #IRC_NICK =
-    #REPORT_HOST = $HOST
-    #REPORT_TCP_PORT =  #defaults to TCP_PORT
-    #REPORT_SSL_PORT =  #defaults to SSL_PORT
-    #RPC_PORT = 8000
-
-
-#
-#MISC
-#
-    #COIN = Bitcoin  # lib/coins.py
-    #NET = mainnet  # lib/coins.py
-    #DB_ENGINE = leveldb
-        #leveldb, rocksdb (You'll need to install appropriate python packages)
-
-    #REORG_LIMIT = 200
-        #maximum number of blocks to be able to handle in a chain
-        #reorganisation.  ElectrumX retains some fairly compact
-        #undo information for this many blocks in levelDB.
-
-    #ANON_LOGS =
-         #Set to anything non-empty to remove IP addresses from logs.
-
-
-#These following environment variables are to help limit server
-#resource consumption and to prevent simple DoS.  Address subscriptions
-#in ElectrumX are very cheap - they consume about 100 bytes of memory
-#each and are processed efficiently.  I feel the defaults are low and
-#encourage you to raise them.
-
-    #MAX_SUBS = 250000
-        #Maximum number of address subscriptions across all sessions
-    #MAX_SESSION_SUBS = 50000
-        #Maximum number of address subscriptions permitted to a single session.
+# See https://github.com/kyuupichan/electrumx/blob/master/docs/ENVIRONMENT.rst for
+# information about other configuration settings you probably want to consider.


### PR DESCRIPTION
The current config file has a few issues:

 - It suggests that a syntax like `COIN = Bitcoin # comment` would do something else than setting `COIN` to `Bitcoin # comment`
 - It doesn't contain all settings
 - It contains some settings that are not used (e.g. `ELECTRUMX`)

To minimize maintainment overhead, I suggest to keep the default config file small and link to the appropriate documentation that should  be up to date.

Closes: #145