### PR TITLE
Pass information about the latest client version to the client

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -72,6 +72,7 @@ class Coin(object):
     # Peer discovery
     PEER_DEFAULT_PORTS = {'t': '50001', 's': '50002'}
     PEERS = []
+    LATEST_CLIENT_VERSION_URL = None
 
     @classmethod
     def lookup_coin_class(cls, name, net):
@@ -332,6 +333,7 @@ class Bitcoin(Coin):
     IRC_PREFIX = "E_"
     IRC_CHANNEL = "#electrum"
     RPC_PORT = 8332
+    LATEST_CLIENT_VERSION_URL = "https://electrum.org/version"
     PEERS = [
         'btc.smsys.me s995',
         'electrum.be s t',

--- a/server/controller.py
+++ b/server/controller.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
+import aiohttp
 import pylru
 
 from lib.jsonrpc import JSONSessionBase, RPCError
@@ -871,3 +872,15 @@ class Controller(util.LoggedClass):
     def donation_address(self):
         '''Return the donation address as a string, empty if there is none.'''
         return self.env.donation_address
+
+    @util.expiring_cachedproperty(86400)
+    async def latest_version(self):
+        if not self.coin.LATEST_CLIENT_VERSION_URL:
+            return None
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self.coin.LATEST_CLIENT_VERSION_URL) as response:
+                if response.status == 200:
+                    return await response.text()
+
+
+

--- a/server/session.py
+++ b/server/session.py
@@ -125,6 +125,7 @@ class ElectrumX(SessionBase):
             'server.features': self.server_features,
             'server.peers.subscribe': self.peers_subscribe,
             'server.version': self.server_version,
+            'client.latest_version': self.client_latest_version
         }
 
     def sub_count(self):
@@ -336,6 +337,13 @@ class ElectrumX(SessionBase):
         if protocol_version is not None:
             self.protocol_version = protocol_version
         return version.VERSION
+
+    async def client_latest_version(self):
+        v = await self.controller.latest_version
+        if not v:
+            raise RPCError("unknown method: '{}'".format("client.latest_version"),
+                           JSONRPC.METHOD_NOT_FOUND)
+        return v
 
     async def transaction_broadcast(self, raw_tx):
         '''Broadcast a raw transaction to the network.

--- a/tests/lib/test_util.py
+++ b/tests/lib/test_util.py
@@ -1,3 +1,5 @@
+import time
+
 from lib import util
 
 
@@ -19,9 +21,18 @@ def test_cachedproperty():
             cls.CALL_COUNT += 1
             return cls.CALL_COUNT
 
+        @util.expiring_cachedproperty(0.1)
+        def expiring_prop(self):
+            self.call_count += 1
+            return self.call_count
+
     t = Target()
     assert t.prop == t.prop == 1
     assert Target.cls_prop == Target.cls_prop == 1
+    assert t.expiring_prop == 2
+    assert t.expiring_prop == 2
+    time.sleep(0.1)
+    assert t.expiring_prop == 3
 
 
 def test_deep_getsizeof():


### PR DESCRIPTION
This is based on this IRC conversation:

```
> [11:23:56] <skace> ThomasV: any way to allow proxy settings for 'auto update' feature... or... make it a check box "check for new updates" yes/no
> [11:24:04] <skace> i hate having to check the site if something new
> [11:25:11] <ThomasV> skace: I think we need to do it so that the client checks from the electrum server, instead of requesting directly from electrum.org
> [11:25:22] <ThomasV> that way there's no privacy loss
> [11:25:43] <ThomasV> the way it used to work was direct https request
> [11:26:35] <skace> so server would have to query website?
> [11:26:42] <skace> i would of assumed proxy settings would be enough
> [11:32:34] <ThomasV> not everyone uses a proxy
> [11:32:54] <ThomasV> it's better if the server queries the website, I think
> [11:36:52] <EagleTM> just an idea: could be made a server feature in e-x? server queries website periodically, gives info to client.
> [11:37:09] <ThomasV> EagleTM: yes, that's the idea
> [11:37:25] <EagleTM> ah ok ;) yes just re-read it
```

So the idea is that the server regularly checks the website for the latest client version. The client would then get that information from the server and notify the user if something newer is available.

I'm not sure if the `Coin` class is the best place for the `latest_version` method. Maybe it would make more sense to move that to the `Session` class?