### PR TITLE
Update controller.py

### DIFF
--- a/server/controller.py
+++ b/server/controller.py
@@ -198,7 +198,7 @@ class Controller(util.LoggedClass):
     async def main_loop(self):
         '''Controller main loop.'''
         if self.env.rpc_port is not None:
-            await self.start_server('RPC', 'localhost', self.env.rpc_port)
+            await self.start_server('RPC', '127.0.0.1', self.env.rpc_port)
         self.ensure_future(self.bp.main_loop())
         self.ensure_future(self.wait_for_bp_catchup())
 


### PR DESCRIPTION
I have a problem in version 1.0.15. 
localrpc error info 'ERROR:Controller:RPC server failed to listen on localhost:8000 :[Errno 99] error while attempting to bind on address ('::1', 8000, 0, 0): cannot assign requested address' If you starting service. 
when you replace 'localhost' to '127.0.0.1' in control.py . it is OK! 
bacause someome don't set localhost:127.0.0.1 in host or the system cannot parse
I've found this problem on my 3 servers. 