### PR TITLE
Allow setting an alternate asyncio event loop policy (e.g. uvloop)

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -102,6 +102,15 @@ These environment variables are optional:
   to blank.  The default is appropriate for **COIN** and **NET**
   (e.g., 8000 for Bitcoin mainnet) if not set.
 
+* **EVENT_LOOP_POLICY**
+
+  Python path to an asyncio event loop policy class. The policy determines
+  what event loop implementation will be used to initiate and respond to
+  networking events.
+
+  For example, this can be used to employ uvloop if it is installed by
+  setting it to `uvloop.EventLoopPolicy`
+
 * **DONATION_ADDRESS**
 
   The server donation address reported to Electrum clients.  Defaults

--- a/electrumx_server.py
+++ b/electrumx_server.py
@@ -36,6 +36,13 @@ def main_loop():
         raise RuntimeError('DO NOT RUN AS ROOT! Create an unprivileged user '
                            'account and use that')
 
+    env = Env()
+
+    policy = env.loop_policy
+    if policy is not None:
+        logging.info("Using event loop policy {}.".format(policy))
+        asyncio.set_event_loop_policy(policy())
+
     loop = asyncio.get_event_loop()
     # loop.set_debug(True)
 
@@ -53,7 +60,7 @@ def main_loop():
                     'accept_connection2()' in repr(context.get('task'))):
                 loop.default_exception_handler(context)
 
-    controller = Controller(Env())
+    controller = Controller(env)
     future = asyncio.ensure_future(controller.main_loop())
 
     # Install signal handlers


### PR DESCRIPTION
I wanted the option to use uvloop. I didn't notice a significant difference networking on the loopback interface, but it's possible some will find it faster than the unix select loop that comes with CPython.