### PR TITLE
Fix KeyError on incorrect genesis hash

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -315,7 +315,7 @@ class DB(util.LoggedClass):
                 genesis_hash = genesis_hash.decode()
             if genesis_hash != self.coin.GENESIS_HASH:
                 raise self.DBError('DB genesis hash {} does not match coin {}'
-                                   .format(state['genesis_hash'],
+                                   .format(genesis_hash,
                                            self.coin.GENESIS_HASH))
             self.db_height = state['height']
             self.db_tx_count = state['tx_count']


### PR DESCRIPTION
Fix KeyError that occurs when creating an exception due to incorrect genesis hash.