### PR TITLE
Outgoing connections should use the same IP we're listening on

### DIFF
--- a/server/peers.py
+++ b/server/peers.py
@@ -560,9 +560,11 @@ class PeerManager(util.LoggedClass):
             create_connection = self.proxy.create_connection
         else:
             create_connection = self.loop.create_connection
+            
+        local_addr = (self.env.host, None) if self.env.host else None    
 
         protocol_factory = partial(PeerSession, peer, self, kind)
-        coro = create_connection(protocol_factory, peer.host, port, ssl=sslc)
+        coro = create_connection(protocol_factory, peer.host, port, ssl=sslc, local_addr=local_addr)
         callback = partial(self.connection_done, peer, port_pairs)
         self.ensure_future(coro, callback)
 


### PR DESCRIPTION
This is important on a machine with more than one IP if a specific HOST= is configured so we're not listening on all IPs.  
Avoids source-destination mismatches when advertizing our peer.
