### PR TITLE
Fix WIF_BYTE for Monacoin

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -902,7 +902,7 @@ class Monacoin(Coin):
     XPRV_VERBYTES = bytes.fromhex("0488ADE4")
     P2PKH_VERBYTE = bytes.fromhex("32")
     P2SH_VERBYTES = [bytes.fromhex("37"), bytes.fromhex("05")]
-    WIF_BYTE = bytes.fromhex("B2")
+    WIF_BYTE = bytes.fromhex("B0")
     GENESIS_HASH = ('ff9f1c0116d19de7c9963845e129f9ed'
                     '1bfc0b376eb54fd7afa42e0d418c8bb6')
     DESERIALIZER = DeserializerSegWit


### PR DESCRIPTION
WIF_BYTE was changed \xb2 to \xb0 since Monacoin-core develop-0.10 brance.
This issue was pointed out by @wakiyamap.

Reference: 
 https://github.com/monacoinproject/monacoin/blob/97564cc5a51be1a05c055ac66d534d0ee50c84b4/src/chainparams.cpp#L135