### PR TITLE
Add ALLOW_ROOT option

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -64,6 +64,10 @@ Miscellaneous
 
 These environment variables are optional:
 
+* **ALLOW_ROOT**
+
+  Set this environment variable to "1" to allow running ElectrumX as root.
+
 * **NET**
 
   Must be a *NET* from one of the **Coin** classes in `lib/coins.py`_.

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -66,7 +66,7 @@ These environment variables are optional:
 
 * **ALLOW_ROOT**
 
-  Set this environment variable to "1" to allow running ElectrumX as root.
+  Set this environment variable to anything non-empty to allow running ElectrumX as root.
 
 * **NET**
 

--- a/server/controller.py
+++ b/server/controller.py
@@ -55,8 +55,8 @@ class Controller(util.LoggedClass):
             raise RuntimeError('RUNNING AS ROOT IS STRONGLY DISCOURAGED!\n'
                                'You shoud create an unprivileged user account '
                                'and use that.\n'
-                               'If you\'d like to continue as root, please run '
-                               'this again with ALLOW_ROOT=1')
+                               'To continue as root anyway, restart with '
+                               'environment variable ALLOW_ROOT non-empty')
 
         # Set the event loop policy before doing anything asyncio
         self.logger.info('event loop policy: {}'.format(env.loop_policy))

--- a/server/controller.py
+++ b/server/controller.py
@@ -51,9 +51,12 @@ class Controller(util.LoggedClass):
         if sys.version_info < (3, 5, 3):
             raise RuntimeError('Python >= 3.5.3 is required to run ElectrumX')
 
-        if os.geteuid() == 0:
-            raise RuntimeError('DO NOT RUN AS ROOT! Create an unprivileged '
-                               'user account and use that')
+        if os.geteuid() == 0 and not env.allow_root:
+            raise RuntimeError('RUNNING AS ROOT IS STRONGLY DISCOURAGED!\n'
+                               'You shoud create an unprivileged user account '
+                               'and use that.\n'
+                               'If you\'d like to continue as root, please run '
+                               'this again with ALLOW_ROOT=1')
 
         # Set the event loop policy before doing anything asyncio
         self.logger.info('event loop policy: {}'.format(env.loop_policy))

--- a/server/env.py
+++ b/server/env.py
@@ -29,6 +29,7 @@ class Env(lib_util.LoggedClass):
     def __init__(self):
         super().__init__()
         self.obsolete(['UTXO_MB', 'HIST_MB', 'NETWORK'])
+        self.allow_root = self.boolean('ALLOW_ROOT', False)
         self.db_dir = self.required('DB_DIRECTORY')
         self.daemon_url = self.required('DAEMON_URL')
         coin_name = self.required('COIN').strip()


### PR DESCRIPTION
Resolves https://github.com/kyuupichan/electrumx/issues/267

Default behaviour is unchanged. However when running as root the error message will now be:

```
RuntimeError: RUNNING AS ROOT IS STRONGLY DISCOURAGED!
You shoud create an unprivileged user account and use that.
If you'd like to continue as root, please run this again with ALLOW_ROOT=1
CRITICAL:root:ElectrumX server terminated abnormally
```

Running as root with `ALLOW_ROOT=1` will run without error.