### PR TITLE
[Monacoin] Append the new seed node.

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -952,6 +952,7 @@ class Monacoin(Coin):
         'electrumx.tamami-foundation.org s t',
         'electrumx1.movsign.info t',
         'electrumx2.movsign.info t',
+        'electrum-mona.bitbank.cc s t',
     ]
 
 


### PR DESCRIPTION
electrum-mona.bitbank.cc (tcp/ssl).

More info is in their technical blog entry (in Japanase).
https://bitbank.cc/blog/engineer20171005/