### PR TITLE
update peers for BitcoinSegwitTestnet and BitcoinCashTestnet

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -393,12 +393,7 @@ class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
     '''Bitcoin Testnet for Bitcoin Cash daemons.'''
     NAME = "BitcoinCash"
     PEERS = [
-        'electrum.akinbo.org s t',
-        'he36kyperp3kbuxu.onion s t',
-        'electrum-btc-testnet.petrkr.net s t',
-        'testnet.hsmiths.com t53011',
-        'hsmithsxurybd7uh.onion t53011 s53012',
-        'ELEX05.blackpole.online t52001 s52002',
+        'electrum-testnet-abc.criptolayer.net s50112',
     ]
 
 
@@ -406,6 +401,13 @@ class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):
     '''Bitcoin Testnet for Core bitcoind >= 0.13.1.'''
     NAME = "BitcoinSegwit"
     DESERIALIZER = DeserializerSegWit
+    PEERS = [
+        'electrum.akinbo.org s t',
+        'he36kyperp3kbuxu.onion s t',
+        'testnet.hsmiths.com t53011 s53012',
+        'hsmithsxurybd7uh.onion t53011 s53012',
+        'testnetnode.arihanc.com s t',
+    ]
 
 
 class BitcoinSegwitRegtest(BitcoinSegwitTestnet):


### PR DESCRIPTION
See #282.

I've tested all servers for BTC testnet and BCH testnet listed in this current repo, so
https://github.com/kyuupichan/electrumx/blob/05d6351686bfa34738ab2beedef43a049ef33337/lib/coins.py#L395-L402
and also the BTC testnet servers from the Electrum repo
https://github.com/spesmilo/electrum/blob/5127dabb0df823529161a392490ec0357ad8affb/lib/servers_testnet.json
and also the BCH testnet servers from the Electron Cash repo
https://github.com/fyookball/electrum/blob/bbe2ef61c07e0bb386c0772982fbaaf97e8b3b03/lib/network.py#L72-L75

These are the ones that were working during my tests.
