### PR TITLE
Add Hush

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -743,6 +743,46 @@ class FairCoin(Coin):
             'creatorId': creatorId,
         }
 
+class Hush(Coin):
+    NAME                 = "Hush"
+    SHORTNAME            = "HUSH"
+    NET                  = "mainnet"
+    P2PKH_VERBYTE        = bytes.fromhex("1CB8")
+    P2SH_VERBYTES        = [bytes.fromhex("1CBD")]
+    WIF_BYTE             = bytes.fromhex("80")
+    GENESIS_HASH         = ( '0003a67bc26fe564b75daf11186d3606'
+                             '52eb435a35ba3d9d3e7e5d5f8e62dc17')
+    STATIC_BLOCK_HEADERS = False
+    BASIC_HEADER_SIZE    = 140 # Excluding Equihash solution
+    DESERIALIZER         = DeserializerZcash
+    TX_COUNT             = 392409
+    TX_COUNT_HEIGHT      = 171777
+    TX_PER_BLOCK         = 5
+    IRC_PREFIX           = ""
+    IRC_CHANNEL          = ""
+    RPC_PORT             = 8888
+    REORG_LIMIT          = 800
+
+    @classmethod
+    def electrum_header(cls, header, height):
+        version, = struct.unpack('<I', header[:4])
+        timestamp, bits = struct.unpack('<II', header[100:108])
+
+        return {
+            'block_height': height,
+            'version': version,
+            'prev_block_hash': hash_to_str(header[4:36]),
+            'merkle_root': hash_to_str(header[36:68]),
+            'timestamp': timestamp,
+            'bits': bits,
+            'nonce': hash_to_str(header[108:140]),
+        }
+
+    @classmethod
+    def block_header(cls, block, height):
+        '''Return the block header bytes'''
+        deserializer = cls.DESERIALIZER(block)
+        return deserializer.read_header(height, cls.BASIC_HEADER_SIZE)
 
 class Zcash(Coin):
     NAME = "Zcash"

--- a/lib/coins.py
+++ b/lib/coins.py
@@ -760,7 +760,7 @@ class Hush(Coin):
     TX_PER_BLOCK         = 5
     IRC_PREFIX           = ""
     IRC_CHANNEL          = ""
-    RPC_PORT             = 8888
+    RPC_PORT             = 8822
     REORG_LIMIT          = 800
 
     @classmethod

--- a/lib/coins.py
+++ b/lib/coins.py
@@ -758,8 +758,6 @@ class Hush(Coin):
     TX_COUNT             = 392409
     TX_COUNT_HEIGHT      = 171777
     TX_PER_BLOCK         = 5
-    IRC_PREFIX           = ""
-    IRC_CHANNEL          = ""
     RPC_PORT             = 8822
     REORG_LIMIT          = 800
 


### PR DESCRIPTION
This adds Hush to electrumX. This commit has been powering transactions on main-net via the superNET fork:

https://github.com/SuperNETorg/electrumx/commit/8e55df9a7b5ea9bac01019e9183e36cd45893e30

which they are already running in production.

Additionally, this code was used to do a cross-chain atomic swap between HUSH and KMD, some links:


alicepayment 0.1001 KMD https://kmd.explorer.supernet.org/tx/4e45b45d501fb5892e1409c181db8b4d63c060cb954bb4e4e06dafdb4461ca50
bobpayment 0.11299695 HUSH https://explorer.myhush.org/tx/cda7db0094d8ee0181e2b48ac5873de2d0586e021bbf69f39f9fa61b7f624e00
bobdeposit 0.12710906 HUSH https://explorer.myhush.org/tx/0d46062aa3a07c56ebfd7fc458a76f5f188dee1e925aa505c879dba68dfde48d

Thanks for Electrum, it's awesome open source software! 😸 