### PR TITLE
Add electrum-ltc.wilv.in to Litecoin Peers.

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -492,6 +492,7 @@ class Litecoin(Coin):
         'elec.luggs.co s444',
         'electrum-ltc.bysh.me s t',
         'electrum-ltc.ddns.net s t',
+        'electrum-ltc.wilv.in s t',
         'electrum.cryptomachine.com p1000 s t',
         'electrum.ltc.xurious.com s t',
         'eywr5eubdbbe2laq.onion s50008 t50007',


### PR DESCRIPTION
I'm running an Litecoin ElectrumX Node for some time now.
It's got generally good uptime and it is located in Amsterdam. 

I would love to have it included in the coins.py peers list for Litecoin.

Thanks for considering.
Love electrumX keep up the good work!