### PR TITLE
fix: estimatesmartfee when there is no feerate from daemon

### DIFF
--- a/server/daemon.py
+++ b/server/daemon.py
@@ -249,7 +249,7 @@ class Daemon(LoggedClass):
         '''Return the fee estimate for the given parameters.'''
         if await self._is_rpc_available('estimatesmartfee'):
             estimate = await self._send_single('estimatesmartfee', params)
-            return estimate['feerate']
+            return estimate.get('feerate', -1)
         return await self._send_single('estimatefee', params)
 
     async def getnetworkinfo(self):


### PR DESCRIPTION
I've missed this in #300.

There has been a change regarding what the daemon returns around 0.15 (in case of Bitcoin Core) if a fee estimate can't be made.

Bitcoin Core 0.14.2:
```
{
  "feerate": -1,
  "blocks": 25
}
```


Bitcoin Core 0.15.0.1:
```
{
  "errors": [
    "Insufficient data or no feerate found"
  ],
  "blocks": 0
}
```

Without this change, stack trace:
```
ERROR:ElectrumX:[0] Traceback (most recent call last):
  File "/home/user/wspace/electrumx/lib/jsonrpc.py", line 530, in process_single_request
    result = await self.handle_payload(payload, self.request_handler)
  File "/home/user/wspace/electrumx/lib/jsonrpc.py", line 610, in handle_payload
    return await handler(**kw_args)
  File "/home/user/wspace/electrumx/server/controller.py", line 828, in estimatefee
    return await self.daemon_request('estimatefee', [number])
  File "/home/user/wspace/electrumx/server/controller.py", line 671, in daemon_request
    return await getattr(self.daemon, method)(*args)
  File "/home/user/wspace/electrumx/server/daemon.py", line 252, in estimatefee
    return estimate['feerate']
KeyError: 'feerate'
```