### PR TITLE
Workaround for Travis build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "nightly"
 # command to install dependencies
 install:
+  - pip install pytest==3.2.5
   - pip install aiohttp
   - pip install ecdsa
   - pip install plyvel


### PR DESCRIPTION
Apparently something in the release of pytest 3.3.0 broke our (arguably quite hacky) database closing method:

https://github.com/kyuupichan/electrumx/blob/master/tests/server/test_storage.py#L27-L29

This reverts to pytest 3.2 for now until I find out how to fix this.