### PR TITLE
Update: install_electrumx.sh

### DIFF
--- a/contrib/raspberrypi3/install_electrumx.sh
+++ b/contrib/raspberrypi3/install_electrumx.sh
@@ -3,6 +3,9 @@
 # install electrumx
 ###################
 
+# Remove "raspi-copies-and-fills" as it breaks the upgrade process
+sudo apt-get purge raspi-copies-and-fills
+
 # upgrade raspbian to 'stretch' distribution
 sudo echo 'deb http://mirrordirector.raspbian.org/raspbian/ testing main contrib non-free rpi' > /etc/apt/sources.list.d/stretch.list
 sudo apt-get update


### PR DESCRIPTION
Remove "raspi-copies-and-fills" as it breaks the upgrade process