### PR TITLE
Enable verbose mode in blockchain.transaction.get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - pip install plyvel
   - pip install pyrocksdb
   - pip install pytest-cov
+  - pip install pylru
 # command to run tests
 script: pytest --cov=server --cov=lib --cov=wallet
 # Dont report coverage from nightly

--- a/docs/PROTOCOL.rst
+++ b/docs/PROTOCOL.rst
@@ -934,11 +934,7 @@ Protocol version 1.2 introduces new methods `blockchain.block.headers`,
   and support will be removed in some future protocol version.  You should update your code to use `blockchain.block.headers`
   and `Script Hashes`_ with the scripthash methods introduced in protocol 1.1 instead.
 
-* `blockchain.transaction.get` now have the optional parameter *verbose*. In verbose mode (default=False) the
-  result is enriched with the relative inclusion blockhash, if any.
-
-
-
+* `blockchain.transaction.get` now has an optional parameter *verbose*.
 
 blockchain.block.headers
 ========================
@@ -1014,17 +1010,18 @@ blockchain.transaction.get
 
 Return a raw transaction.
 
-  blockchain.transaction.get(**tx_hash**, **verbose** = [False])
+  blockchain.transaction.get(**tx_hash**, **verbose**=False)
 
   **tx_hash**
 
     The transaction hash as a hexadecimal string.
 
-  **verbose** [optional]
-    Set verbose mode (default = False).
+  **verbose**
+    Verbose mode, passed on to bitcoind in **getrawtransaction**.
 
 **Response**
 
    In non-verbose mode return the raw transaction as a hexadecimal string.
 
-   With verbose=True, return a JSON object with the deserialized transaction.
+   If verbose, returns what your coin's bitcoind returns; see its
+   documentation for details.

--- a/docs/PROTOCOL.rst
+++ b/docs/PROTOCOL.rst
@@ -532,7 +532,7 @@ blockchain.transaction.get
 
 Return a raw transaction.
 
-  blockchain.transaction.get(**tx_hash**, **height**)
+  blockchain.transaction.get(**tx_hash**, **height**, **verbose** = [False])
 
   **tx_hash**
 
@@ -544,9 +544,17 @@ Return a raw transaction.
     is optional and ignored; it is recommended that clients do not
     send it as it will be removed in a future protocol version.
 
+  **verbose** [optional]
+    Set verbose mode (default = False).
+
 **Response**
 
-    The raw transaction as a hexadecimal string.
+   In non-verbose mode return the raw transaction as a hexadecimal string.
+
+   With verbose=True, return the deserialized JSON transaction.
+   Also return the key {"blockhash": <hex block hash>} if the transaction is included into a block.
+
+   Return a null value if the transaction is not found.
 
 
 blockchain.transaction.get_merkle
@@ -930,11 +938,17 @@ Protocol Version 1.2
 Protocol version 1.2 introduces new methods `blockchain.block.headers`,
 `mempool.get_fee_histogram`.
 
-`blockchain.block.get_chunk` and all methods beginning
+* `blockchain.block.get_chunk` and all methods beginning
  `blockchain.address.` are deprecated and support will be removed in
  some future protocol version.  You should update your code to use
  `blockchain.block.headers` and `Script Hashes`_ with the scripthash
  methods introduced in protocol 1.1 instead.
+
+* `blockchain.transaction.get` now have the optional parameter *verbose*.
+ In verbose mode (default=False) the transaction is deserialized in JSON.
+ Also, if the transaction is included in a block, the related blockhash is returned.
+ Note: On some coins verbose mode may not be available and an error is returned.
+
 
 blockchain.block.headers
 ========================

--- a/docs/PROTOCOL.rst
+++ b/docs/PROTOCOL.rst
@@ -551,10 +551,32 @@ Return a raw transaction.
 
    In non-verbose mode return the raw transaction as a hexadecimal string.
 
-   With verbose=True, return the deserialized JSON transaction.
-   Also return the key {"blockhash": <hex block hash>} if the transaction is included into a block.
+   With verbose=True, return an object with keys "hex", that is the raw transaction, and "blockhash".
+   When the transaction is included into a block, the "blockhash" value will be the relative blockhash.
 
    Return a null value if the transaction is not found.
+
+**Response Examples**
+
+  Non verbose:
+
+  ::
+    02000000029d4d491c11a84285203147ab8fa39335834ae1a1946f2a63b8cf9d33326dfd24010000006a47304402204a063e2a589dba0bba49ec37d05f90e5b232ba70af08e1eb8a34dbaf7c7a36be022071a46a726482896873a2d9bb6587238662a64c0304069a8b57c61c30ddb1b21c012102cd44f359b884463e4b22c614d98f43a58d23214119340d4ab6dce2f556d4f712feffbf0ba5bdcd88b97e3082d027e7d91f2bd6c59735724e37f51341390cdfa85ee15b77f01feffffff0200ca9a3b0000000017a914b18d08cc1c9fa531aca09851c3e559e1572e1a738718a8f008000000001976a914a185ab6529459aa3b9d8c0924ca5e66d30cfd72088ac63020000
+
+
+  Verbose mode:
+
+  ::
+      {
+
+         "hex": "02000000029d4d491c11a84285203147ab8fa39335834ae1a1946f2a63b8cf9d33326dfd24010000006a47304402204a063e2a589dba0bba49ec37d05f90e5b232ba70af08e1eb8a34dbaf7c7a36be022071a46a726482896873a2d9bb6587238662a64c0304069a8b57c61c30ddb1b21c012102cd44f359b884463e4b22c614d98f43a58d23214119340d4ab6dce2f556d4f712feffbf0ba5bdcd88b97e3082d027e7d91f2bd6c59735724e37f51341390cdfa85ee15b77f01feffffff0200ca9a3b0000000017a914b18d08cc1c9fa531aca09851c3e559e1572e1a738718a8f008000000001976a914a185ab6529459aa3b9d8c0924ca5e66d30cfd72088ac63020000",
+         "blockhash": "000000000d23bc62fd701706ba32e2af08e80ef1461b3c36d8f923281b0321d0"
+
+      }
+
+
+
+
 
 
 blockchain.transaction.get_merkle
@@ -932,22 +954,17 @@ Get a list of features and services supported by the server.
       "hash_function": "sha256"
   }
 
-Protocol Version 1.2
---------------------
-
 Protocol version 1.2 introduces new methods `blockchain.block.headers`,
 `mempool.get_fee_histogram`.
 
-* `blockchain.block.get_chunk` and all methods beginning
- `blockchain.address.` are deprecated and support will be removed in
- some future protocol version.  You should update your code to use
- `blockchain.block.headers` and `Script Hashes`_ with the scripthash
- methods introduced in protocol 1.1 instead.
+* `blockchain.block.get_chunk` and all methods beginning `blockchain.address.` are deprecated
+  and support will be removed in some future protocol version.  You should update your code to use `blockchain.block.headers`
+  and `Script Hashes`_ with the scripthash methods introduced in protocol 1.1 instead.
 
-* `blockchain.transaction.get` now have the optional parameter *verbose*.
- In verbose mode (default=False) the transaction is deserialized in JSON.
- Also, if the transaction is included in a block, the related blockhash is returned.
- Note: On some coins verbose mode may not be available and an error is returned.
+* `blockchain.transaction.get` now have the optional parameter *verbose*. In verbose mode (default=False) the
+  result is enriched with the relative inclusion blockhash, if any. Feature may have be unavailable.
+
+
 
 
 blockchain.block.headers
@@ -992,7 +1009,7 @@ Return concatenated block headers as hexadecimal from the main chain.
 
   {
       "count": 2,
-      "hex": "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299'"
+      "hex": "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299"
       "max": 2016
   }
 

--- a/docs/PROTOCOL.rst
+++ b/docs/PROTOCOL.rst
@@ -532,7 +532,7 @@ blockchain.transaction.get
 
 Return a raw transaction.
 
-  blockchain.transaction.get(**tx_hash**, **height**, **verbose** = [False])
+  blockchain.transaction.get(**tx_hash**, **height**)
 
   **tx_hash**
 
@@ -544,39 +544,9 @@ Return a raw transaction.
     is optional and ignored; it is recommended that clients do not
     send it as it will be removed in a future protocol version.
 
-  **verbose** [optional]
-    Set verbose mode (default = False).
-
 **Response**
 
-   In non-verbose mode return the raw transaction as a hexadecimal string.
-
-   With verbose=True, return an object with keys "hex", that is the raw transaction, and "blockhash".
-   When the transaction is included into a block, the "blockhash" value will be the relative blockhash.
-
-   Return a null value if the transaction is not found.
-
-**Response Examples**
-
-  Non verbose:
-
-  ::
-    02000000029d4d491c11a84285203147ab8fa39335834ae1a1946f2a63b8cf9d33326dfd24010000006a47304402204a063e2a589dba0bba49ec37d05f90e5b232ba70af08e1eb8a34dbaf7c7a36be022071a46a726482896873a2d9bb6587238662a64c0304069a8b57c61c30ddb1b21c012102cd44f359b884463e4b22c614d98f43a58d23214119340d4ab6dce2f556d4f712feffbf0ba5bdcd88b97e3082d027e7d91f2bd6c59735724e37f51341390cdfa85ee15b77f01feffffff0200ca9a3b0000000017a914b18d08cc1c9fa531aca09851c3e559e1572e1a738718a8f008000000001976a914a185ab6529459aa3b9d8c0924ca5e66d30cfd72088ac63020000
-
-
-  Verbose mode:
-
-  ::
-      {
-
-         "hex": "02000000029d4d491c11a84285203147ab8fa39335834ae1a1946f2a63b8cf9d33326dfd24010000006a47304402204a063e2a589dba0bba49ec37d05f90e5b232ba70af08e1eb8a34dbaf7c7a36be022071a46a726482896873a2d9bb6587238662a64c0304069a8b57c61c30ddb1b21c012102cd44f359b884463e4b22c614d98f43a58d23214119340d4ab6dce2f556d4f712feffbf0ba5bdcd88b97e3082d027e7d91f2bd6c59735724e37f51341390cdfa85ee15b77f01feffffff0200ca9a3b0000000017a914b18d08cc1c9fa531aca09851c3e559e1572e1a738718a8f008000000001976a914a185ab6529459aa3b9d8c0924ca5e66d30cfd72088ac63020000",
-         "blockhash": "000000000d23bc62fd701706ba32e2af08e80ef1461b3c36d8f923281b0321d0"
-
-      }
-
-
-
-
+    The raw transaction as a hexadecimal string.
 
 
 blockchain.transaction.get_merkle
@@ -954,6 +924,9 @@ Get a list of features and services supported by the server.
       "hash_function": "sha256"
   }
 
+Protocol Version 1.2
+--------------------
+
 Protocol version 1.2 introduces new methods `blockchain.block.headers`,
 `mempool.get_fee_histogram`.
 
@@ -962,7 +935,7 @@ Protocol version 1.2 introduces new methods `blockchain.block.headers`,
   and `Script Hashes`_ with the scripthash methods introduced in protocol 1.1 instead.
 
 * `blockchain.transaction.get` now have the optional parameter *verbose*. In verbose mode (default=False) the
-  result is enriched with the relative inclusion blockhash, if any. Feature may have be unavailable.
+  result is enriched with the relative inclusion blockhash, if any.
 
 
 
@@ -1034,3 +1007,24 @@ intervals is currently not part of the protocol.
 
 .. _JSON RPC 1.0: http://json-rpc.org/wiki/specification
 .. _JSON RPC 2.0: http://json-rpc.org/specification
+
+
+blockchain.transaction.get
+==========================
+
+Return a raw transaction.
+
+  blockchain.transaction.get(**tx_hash**, **verbose** = [False])
+
+  **tx_hash**
+
+    The transaction hash as a hexadecimal string.
+
+  **verbose** [optional]
+    Set verbose mode (default = False).
+
+**Response**
+
+   In non-verbose mode return the raw transaction as a hexadecimal string.
+
+   With verbose=True, return a JSON object with the deserialized transaction.

--- a/server/controller.py
+++ b/server/controller.py
@@ -842,13 +842,14 @@ class Controller(ServerBase):
         to the daemon's memory pool.'''
         return await self.daemon_request('relayfee')
 
-    async def transaction_get(self, tx_hash):
+    async def transaction_get(self, tx_hash, verbose=False):
         '''Return the serialized raw transaction given its hash
 
         tx_hash: the transaction hash as a hexadecimal string
+        verbose: (optional, default=False), enable\disable verbose mode
         '''
         self.assert_tx_hash(tx_hash)
-        return await self.daemon_request('getrawtransaction', tx_hash)
+        return await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
 
     async def transaction_get_1_0(self, tx_hash, height=None):
         '''Return the serialized raw transaction given its hash

--- a/server/controller.py
+++ b/server/controller.py
@@ -849,19 +849,7 @@ class Controller(ServerBase):
         verbose: (optional, default=False), enable\disable verbose mode
         '''
         self.assert_tx_hash(tx_hash)
-        transaction = await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
-        if not transaction:
-            return
-        if verbose and isinstance(transaction, dict):
-            try:
-                return {
-                    'hex': transaction['hex'],
-                    'blockhash': transaction.get('blockhash')
-                }
-            except KeyError:
-                self.logger.exception('verbose mode failed')
-                raise RPCError("error in verbose mode")
-        return transaction
+        return await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
 
     async def transaction_get_1_0(self, tx_hash, height=None):
         '''Return the serialized raw transaction given its hash

--- a/server/controller.py
+++ b/server/controller.py
@@ -849,7 +849,19 @@ class Controller(ServerBase):
         verbose: (optional, default=False), enable\disable verbose mode
         '''
         self.assert_tx_hash(tx_hash)
-        return await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
+        transaction = await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
+        if not transaction:
+            return
+        if verbose and isinstance(transaction, dict):
+            try:
+                return {
+                    'hex': transaction['hex'],
+                    'blockhash': transaction.get('blockhash')
+                }
+            except KeyError:
+                self.logger.exception('verbose mode failed')
+                raise RPCError("error in verbose mode")
+        return transaction
 
     async def transaction_get_1_0(self, tx_hash, height=None):
         '''Return the serialized raw transaction given its hash

--- a/server/controller.py
+++ b/server/controller.py
@@ -846,10 +846,10 @@ class Controller(ServerBase):
         '''Return the serialized raw transaction given its hash
 
         tx_hash: the transaction hash as a hexadecimal string
-        verbose: (optional, default=False), enable\disable verbose mode
+        verbose: passed on to the daemon
         '''
         self.assert_tx_hash(tx_hash)
-        return await self.daemon_request('getrawtransaction', tx_hash, int(verbose))
+        return await self.daemon_request('getrawtransaction', tx_hash, verbose)
 
     async def transaction_get_1_0(self, tx_hash, height=None):
         '''Return the serialized raw transaction given its hash

--- a/server/daemon.py
+++ b/server/daemon.py
@@ -262,9 +262,9 @@ class Daemon(LoggedClass):
         network_info = await self.getnetworkinfo()
         return network_info['relayfee']
 
-    async def getrawtransaction(self, hex_hash):
+    async def getrawtransaction(self, hex_hash, verbose=False):
         '''Return the serialized raw transaction with the given hash.'''
-        return await self._send_single('getrawtransaction', (hex_hash, 0))
+        return await self._send_single('getrawtransaction', (hex_hash, verbose))
 
     async def getrawtransactions(self, hex_hashes, replace_errs=True):
         '''Return the serialized raw transactions with the given hashes.

--- a/server/daemon.py
+++ b/server/daemon.py
@@ -264,7 +264,7 @@ class Daemon(LoggedClass):
 
     async def getrawtransaction(self, hex_hash, verbose=False):
         '''Return the serialized raw transaction with the given hash.'''
-        return await self._send_single('getrawtransaction', (hex_hash, verbose))
+        return await self._send_single('getrawtransaction', (hex_hash, int(verbose)))
 
     async def getrawtransactions(self, hex_hashes, replace_errs=True):
         '''Return the serialized raw transactions with the given hashes.

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -1,0 +1,104 @@
+import asyncio
+from unittest import mock
+
+from lib.jsonrpc import RPCError
+from server.env import Env
+from server.controller import Controller
+
+loop = asyncio.get_event_loop()
+
+
+def set_env():
+    env = mock.create_autospec(Env)
+    env.coin = mock.Mock()
+    env.loop_policy = None
+    env.max_sessions = 0
+    env.max_subs = 0
+    env.max_send = 0
+    env.bandwidth_limit = 0
+    env.identities = ''
+    env.tor_proxy_host = env.tor_proxy_port = None
+    env.peer_discovery = env.PD_SELF = False
+    env.daemon_url = 'http://localhost:8000/'
+    return env
+
+
+async def coro(res):
+    return res
+
+
+def raise_exception(exc, msg):
+    raise exc(msg)
+
+
+def ensure_text_exception(test, exception):
+    res = err = None
+    try:
+        res = loop.run_until_complete(test)
+    except Exception as e:
+        err = e
+    assert isinstance(err, exception), (res, err)
+
+
+def test_transaction_get():
+    async def test_verbose_ignore_by_backend():
+        env = set_env()
+        sut = Controller(env)
+        sut.daemon_request = mock.Mock()
+        sut.daemon_request.return_value = coro('11'*32)
+        res = await sut.transaction_get('ff'*32, True)
+        assert res == '11'*32
+
+    async def test_verbose_ok():
+        env = set_env()
+        sut = Controller(env)
+        sut.daemon_request = mock.Mock()
+        response = {
+            "hex": "00"*32,
+            "blockhash": "ff"*32
+        }
+        sut.daemon_request.return_value = coro(response)
+        res = await sut.transaction_get('ff'*32, True)
+        assert res == response
+
+        response = {
+            "hex": "00"*32,
+            "blockhash": None
+        }
+        sut.daemon_request.return_value = coro(response)
+        res = await sut.transaction_get('ff'*32, True)
+        assert res == response
+
+    async def test_no_verbose():
+        env = set_env()
+        sut = Controller(env)
+        sut.daemon_request = mock.Mock()
+        response = 'cafebabe'*64
+        sut.daemon_request.return_value = coro(response)
+        res = await sut.transaction_get('ff'*32)
+        assert res == response
+
+    async def test_verbose_failure():
+        env = set_env()
+        sut = Controller(env)
+        sut.daemon_request = mock.Mock()
+        sut.daemon_request.return_value = coro(raise_exception(RPCError, 'some unhandled error'))
+        await sut.transaction_get('ff' * 32, True)
+
+    async def test_wrong_txhash():
+        env = set_env()
+        sut = Controller(env)
+        sut.daemon_request = mock.Mock()
+        await sut.transaction_get('cafe')
+        sut.daemon_request.assert_not_called()
+
+    loop.run_until_complete(asyncio.gather(
+        *[
+            test_verbose_ignore_by_backend(),
+            test_verbose_ok(),
+            test_no_verbose()
+        ]
+    ))
+
+    for error_test in [test_verbose_failure, test_wrong_txhash]:
+        ensure_text_exception(error_test(), RPCError)


### PR DESCRIPTION
This PR enable a limited subset of the verbose mode from the getrawtransaction API.
The inclusion blockhash of a given transaction can be now obtained, along with the raw transaction hex.