### PR TITLE
fix 'height' is not define

### DIFF
--- a/server/block_processor.py
+++ b/server/block_processor.py
@@ -221,7 +221,7 @@ class BlockProcessor(server.db.DB):
         await self.controller.run_in_executor(self.flush, True)
         if self.utxo_db.for_sync:
             self.logger.info(f'{self.controller.VERSION} synced to '
-                             f'height {height:,d}')
+                             f'height {self.height:,d}')
         self.open_dbs()
         self.caught_up_event.set()
 


### PR DESCRIPTION
on git master ec2565679a41a9e071ddebb48c3113227aa1bc89

```
ERROR:Controller:uncaught task exception: name 'height' is not defined
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/electrumx-ElectrumX.1.4.3-py3.6.egg/server/controller.py", line 192, in check_task_exception
    task.result()
  File "/usr/local/lib/python3.6/dist-packages/electrumx-ElectrumX.1.4.3-py3.6.egg/server/block_processor.py", line 206, in main_loop
    await task()
  File "/usr/local/lib/python3.6/dist-packages/electrumx-ElectrumX.1.4.3-py3.6.egg/server/block_processor.py", line 223, in first_caught_up
    self.logger.info(f'{self.controller.VERSION} synced to '
NameError: name 'height' is not defined
```