### PR TITLE
Fix bitzeny params and header

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -1292,11 +1292,17 @@ class Bitzeny(Coin):
     ESTIMATE_FEE = 0.001
     RELAY_FEE = 0.001
     DAEMON = daemon.FakeEstimateFeeDaemon
-    TX_COUNT = 1000
-    TX_COUNT_HEIGHT = 10000
+    TX_COUNT = 1408733
+    TX_COUNT_HEIGHT = 1015115
     TX_PER_BLOCK = 1
     RPC_PORT = 9252
     REORG_LIMIT = 1000
+
+    @classmethod
+    def header_hash(cls, header):
+        '''Given a header return the hash.'''
+        import zny_yescrypt
+        return zny_yescrypt.getPoWHash(header)
 
 
 class CanadaeCoin(AuxPowMixin, Coin):


### PR DESCRIPTION
https://github.com/BitzenyCoreDevelopers/electrum-zeny/blob/bitzeny/lib/blockchain.py#L59-#L64
```
def hash_header(header):
    if header is None:
        return '0' * 64
    if header.get('prev_block_hash') is None:
        header['prev_block_hash'] = '00'*32
    return rev_hex(bh2u(zny_yescrypt.getPoWHash(bfh(serialize_header(header)))))
```