### PR TITLE
Add minimum confirmations for getting balance

### DIFF
--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -367,12 +367,16 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
 
 **Signature**
 
-  .. function:: blockchain.scripthash.get_balance(scripthash)
+  .. function:: blockchain.scripthash.get_balance(scripthash, minconf=1)
   .. versionadded:: 1.1
 
   *scripthash*
 
     The script hash as a hexadecimal string.
+
+  *minconf*
+
+    The minimum confirmations a transaction must have in order to be considered confirmed.
 
 **Result**
 


### PR DESCRIPTION
I think it would be good if users were able to decide how many confirmations they need in order to declare a transaction actually confirmed (recommended is 6, Electrum uses 1).

This has been requested (spesmilo/electrum#3779), and also required changes on Electrum (spesmilo/electrum#4391).

Unfortunately I don't have enough storage for deploying and testing my own PR, so please consider this as an untested idea.