### PR TITLE
Change COIN to BitcoinSegwit

### DIFF
--- a/contrib/raspberrypi3/run_electrumx.sh
+++ b/contrib/raspberrypi3/run_electrumx.sh
@@ -4,7 +4,7 @@
 ###############
 
 # configure electrumx
-export COIN=Bitcoin
+export COIN=BitcoinSegwit
 export DAEMON_URL=http://rpcuser:rpcpassword@127.0.0.1
 export NET=mainnet
 export CACHE_MB=400


### PR DESCRIPTION
Since "Bitcoin" is not one of the values in `coins.py` as required according to https://electrumx.readthedocs.io/en/latest/environment.html, I modified this script to use the "BitcoinSegwit" class listed in the file which corresponds to the BTC chain.