### PR TITLE
Hardcoded username directory replaced with ~

### DIFF
--- a/contrib/python3.6/python-3.6.sh
+++ b/contrib/python3.6/python-3.6.sh
@@ -6,7 +6,7 @@
 sudo add-apt-repository ppa:jonathonf/python-3.6
 sudo apt-get update && sudo apt-get install python3.6 python3.6-dev
 
-cd /home/username
+cd ~
 git clone https://github.com/kyuupichan/electrumx.git
 cd electrumx
 sudo python3.6 setup.py install


### PR DESCRIPTION
This change will cd to the current user's home directory, rather than /home/username

We could remove the cd parameter altogether, to chdir to the current user's home directory...