### PR TITLE
Added working DASH Testnet server.

### DIFF
--- a/lib/coins.py
+++ b/lib/coins.py
@@ -821,6 +821,7 @@ class DashTestnet(Dash):
     PEER_DEFAULT_PORTS = {'t': '51001', 's': '51002'}
     PEERS = [
         'electrum.dash.siampm.com s t',
+        'dasht.random.re s54002 t54001',
     ]
 
 


### PR DESCRIPTION
This is the DASH Testnet server I maintain for my development purposes and I intent to keep it running for long term public use. It is dash-0.12.3.x based so it is future-proof. The other existing only DASH Testnet server is offline at the moment.