### PR TITLE
fix for JSON value is not an integer as expected

### DIFF
--- a/server/daemon.py
+++ b/server/daemon.py
@@ -265,7 +265,7 @@ class Daemon(object):
     async def getrawtransaction(self, hex_hash, verbose=False):
         '''Return the serialized raw transaction with the given hash.'''
         return await self._send_single('getrawtransaction',
-                                       (hex_hash, verbose))
+                                       (hex_hash, int(verbose)))
 
     async def getrawtransactions(self, hex_hashes, replace_errs=True):
         '''Return the serialized raw transactions with the given hashes.


### PR DESCRIPTION
Revert a small change from https://github.com/kyuupichan/electrumx/commit/2cb89814b6c8df2d2e19f0a2192c2c7216964140 to fix error
`{"jsonrpc": "2.0", "error": {"code": 2, "message": "daemon error: {'code': -1, 'message': 'JSON value is not an integer as expected'}"}, "id": 1}` when doing blockchain.transaction.get