### PR TITLE
BitcoinCashRegtest Coin Class

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -595,6 +595,15 @@ class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
     ]
 
 
+class BitcoinCashRegtest(BitcoinCashTestnet):
+    NET = "regtest"
+    GENESIS_HASH = ('0f9188f13cb7b2c71f2a335e3a4fc328'
+                    'bf5beb436012afca590b1a11466e2206')
+    PEERS = []
+    TX_COUNT = 1
+    TX_COUNT_HEIGHT = 1
+
+
 class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):
     '''Bitcoin Testnet for Core bitcoind >= 0.13.1.'''
     NAME = "BitcoinSegwit"


### PR DESCRIPTION
There is one for bitcoincash testnet and one for bitcoinsegwit regtest but the bitcoincash regtest was missing and we would like to use this in our unit tests.