### PR TITLE
Improve ElectrumX Extensibility

### DIFF
--- a/electrumx/server/controller.py
+++ b/electrumx/server/controller.py
@@ -102,6 +102,8 @@ class Controller(ServerBase):
         self.mempool = MemPool(self.bp, self)
         self.peer_mgr = PeerManager(env, self)
 
+        self.tcp_server_started = asyncio.Event()
+
     @classmethod
     def short_version(cls):
         '''Return e.g. "1.2" for ElectrumX 1.2'''
@@ -292,6 +294,7 @@ class Controller(ServerBase):
             sslc = ssl.SSLContext(ssl.PROTOCOL_TLS)
             sslc.load_cert_chain(env.ssl_certfile, keyfile=env.ssl_keyfile)
             await self.start_server('SSL', host, env.ssl_port, ssl=sslc)
+        self.tcp_server_started.set()
 
     def notify_sessions(self, touched):
         '''Notify sessions about height changes and touched addresses.'''

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -27,15 +27,18 @@ class Env(EnvBase):
     # Peer discovery
     PD_OFF, PD_SELF, PD_ON = range(3)
 
-    def __init__(self):
+    def __init__(self, coin=None):
         super().__init__()
         self.obsolete(['UTXO_MB', 'HIST_MB', 'NETWORK'])
         self.db_dir = self.required('DB_DIRECTORY')
         self.db_engine = self.default('DB_ENGINE', 'leveldb')
         self.daemon_url = self.required('DAEMON_URL')
-        coin_name = self.required('COIN').strip()
-        network = self.default('NET', 'mainnet').strip()
-        self.coin = Coin.lookup_coin_class(coin_name, network)
+        if coin is not None:
+            self.coin = coin
+        else:
+            coin_name = self.required('COIN').strip()
+            network = self.default('NET', 'mainnet').strip()
+            self.coin = Coin.lookup_coin_class(coin_name, network)
         self.cache_MB = self.integer('CACHE_MB', 1200)
         self.host = self.default('HOST', 'localhost')
         self.reorg_limit = self.integer('REORG_LIMIT', self.coin.REORG_LIMIT)

--- a/tests/server/test_env.py
+++ b/tests/server/test_env.py
@@ -351,3 +351,7 @@ def test_ban_versions():
     assert e.drop_client == re.compile(ban_re)
     assert e.drop_client.match("1.2.3_buggy_client")
     assert e.drop_client.match("1.3.0_good_client") is None
+
+def test_coin_class_provided():
+    e = Env(lib_coins.BitcoinCash)
+    assert e.coin == lib_coins.BitcoinCash


### PR DESCRIPTION
This PR has two new features:

1. A new `Event` attribute on `Controller` called `tcp_server_started` which allows someone integrating electrumx to know when electrumx is finished starting. We're currently using this in an integration testing framework: https://github.com/lbryio/orchstr8/blob/master/orchstr8/services.py#L93

2. `Env` class now accepts a coin class as the first argument, this makes it possible to load coin classes that are not built-in to electrumx, examples from two projects:
  b. https://github.com/lbryio/lbryumx/blob/master/lbryumx_server.py#L20
  a. https://github.com/lbryio/orchstr8/blob/master/orchstr8/services.py#L90