### PR TITLE
make it easier to configure logging for electrumx

### DIFF
--- a/electrumx/lib/env_base.py
+++ b/electrumx/lib/env_base.py
@@ -19,7 +19,7 @@ class EnvBase(object):
         pass
 
     def __init__(self):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.allow_root = self.boolean('ALLOW_ROOT', False)
         self.host = self.default('HOST', 'localhost')
         self.rpc_host = self.default('RPC_HOST', 'localhost')

--- a/electrumx/lib/env_base.py
+++ b/electrumx/lib/env_base.py
@@ -19,7 +19,8 @@ class EnvBase(object):
         pass
 
     def __init__(self):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.allow_root = self.boolean('ALLOW_ROOT', False)
         self.host = self.default('HOST', 'localhost')
         self.rpc_host = self.default('RPC_HOST', 'localhost')

--- a/electrumx/lib/server_base.py
+++ b/electrumx/lib/server_base.py
@@ -36,7 +36,8 @@ class ServerBase(object):
         '''Save the environment, perform basic sanity checks, and set the
         event loop policy.
         '''
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.env = env
 
         # Sanity checks

--- a/electrumx/lib/server_base.py
+++ b/electrumx/lib/server_base.py
@@ -36,7 +36,7 @@ class ServerBase(object):
         '''Save the environment, perform basic sanity checks, and set the
         event loop policy.
         '''
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.env = env
 
         # Sanity checks

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -26,7 +26,8 @@ class Prefetcher(object):
     '''Prefetches blocks (in the forward direction only).'''
 
     def __init__(self, bp):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.bp = bp
         self.caught_up = False
         # Access to fetched_height should be protected by the semaphore

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -26,7 +26,7 @@ class Prefetcher(object):
     '''Prefetches blocks (in the forward direction only).'''
 
     def __init__(self, bp):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.bp = bp
         self.caught_up = False
         # Access to fetched_height should be protected by the semaphore

--- a/electrumx/server/daemon.py
+++ b/electrumx/server/daemon.py
@@ -37,7 +37,8 @@ class Daemon(object):
         '''Raised when the daemon returns an error in its results.'''
 
     def __init__(self, env):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.coin = env.coin
         self.set_urls(env.coin.daemon_urls(env.daemon_url))
         self._height = None

--- a/electrumx/server/daemon.py
+++ b/electrumx/server/daemon.py
@@ -37,7 +37,7 @@ class Daemon(object):
         '''Raised when the daemon returns an error in its results.'''
 
     def __init__(self, env):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.coin = env.coin
         self.set_urls(env.coin.daemon_urls(env.daemon_url))
         self._height = None

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -42,7 +42,7 @@ class DB(object):
         '''Raised on general DB errors generally indicating corruption.'''
 
     def __init__(self, env):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.env = env
         self.coin = env.coin
 

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -42,7 +42,8 @@ class DB(object):
         '''Raised on general DB errors generally indicating corruption.'''
 
     def __init__(self, env):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.env = env
         self.coin = env.coin
 

--- a/electrumx/server/history.py
+++ b/electrumx/server/history.py
@@ -25,7 +25,8 @@ class History(object):
     DB_VERSIONS = [0]
 
     def __init__(self):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         # For history compaction
         self.max_hist_row_entries = 12500
         self.unflushed = defaultdict(partial(array.array, 'I'))

--- a/electrumx/server/history.py
+++ b/electrumx/server/history.py
@@ -25,7 +25,7 @@ class History(object):
     DB_VERSIONS = [0]
 
     def __init__(self):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         # For history compaction
         self.max_hist_row_entries = 12500
         self.unflushed = defaultdict(partial(array.array, 'I'))

--- a/electrumx/server/mempool.py
+++ b/electrumx/server/mempool.py
@@ -33,7 +33,7 @@ class MemPool(object):
     '''
 
     def __init__(self, bp, controller):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.daemon = bp.daemon
         self.controller = controller
         self.coin = bp.coin

--- a/electrumx/server/mempool.py
+++ b/electrumx/server/mempool.py
@@ -33,7 +33,8 @@ class MemPool(object):
     '''
 
     def __init__(self, bp, controller):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         self.daemon = bp.daemon
         self.controller = controller
         self.coin = bp.coin

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -224,7 +224,8 @@ class PeerManager(object):
     Issues a 'peers.subscribe' RPC to them and tells them our data.
     '''
     def __init__(self, env, controller):
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)\
+            .getChild(self.__class__.__name__)
         # Initialise the Peer class
         Peer.DEFAULT_PORTS = env.coin.PEER_DEFAULT_PORTS
         self.env = env

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -224,7 +224,7 @@ class PeerManager(object):
     Issues a 'peers.subscribe' RPC to them and tells them our data.
     '''
     def __init__(self, env, controller):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         # Initialise the Peer class
         Peer.DEFAULT_PORTS = env.coin.PEER_DEFAULT_PORTS
         self.env = env


### PR DESCRIPTION
This PR improves the logging support in electrumx making it easier to configure behavior across the entire package instead of having to target individual classes. For example:

```python
# DEBUG everything:
logging.getLogger('electrumx').setLevel(logging.DEBUG)

# just WARNINGs:
logging.getLogger('electrumx').setLevel(logging.WARNING)
```