### PR TITLE
Server listening

### DIFF
--- a/electrumx/server/controller.py
+++ b/electrumx/server/controller.py
@@ -102,7 +102,8 @@ class Controller(ServerBase):
         self.mempool = MemPool(self.bp, self)
         self.peer_mgr = PeerManager(env, self)
 
-        self.tcp_server_started = asyncio.Event()
+        # Event triggered when electrumx is listening for incoming requests.
+        self.server_listening = asyncio.Event()
 
     @classmethod
     def short_version(cls):
@@ -294,7 +295,7 @@ class Controller(ServerBase):
             sslc = ssl.SSLContext(ssl.PROTOCOL_TLS)
             sslc.load_cert_chain(env.ssl_certfile, keyfile=env.ssl_keyfile)
             await self.start_server('SSL', host, env.ssl_port, ssl=sslc)
-        self.tcp_server_started.set()
+        self.server_listening.set()
 
     def notify_sessions(self, touched):
         '''Notify sessions about height changes and touched addresses.'''

--- a/electrumx/server/controller.py
+++ b/electrumx/server/controller.py
@@ -102,6 +102,8 @@ class Controller(ServerBase):
         self.mempool = MemPool(self.bp, self)
         self.peer_mgr = PeerManager(env, self)
 
+        self.tcp_server_started = asyncio.Event()
+
     @classmethod
     def short_version(cls):
         '''Return e.g. "1.2" for ElectrumX 1.2'''
@@ -292,6 +294,7 @@ class Controller(ServerBase):
             sslc = ssl.SSLContext(ssl.PROTOCOL_TLS)
             sslc.load_cert_chain(env.ssl_certfile, keyfile=env.ssl_keyfile)
             await self.start_server('SSL', host, env.ssl_port, ssl=sslc)
+        self.tcp_server_started.set()
 
     def notify_sessions(self, touched):
         '''Notify sessions about height changes and touched addresses.'''


### PR DESCRIPTION
A new Event attribute on Controller called `server_listening` which allows someone integrating electrumx to know when electrumx is finished starting.