### PR TITLE
fix mempool tx fee calculation typo

### DIFF
--- a/electrumx/server/mempool.py
+++ b/electrumx/server/mempool.py
@@ -120,7 +120,7 @@ class MemPool(object):
             # Convert in_pairs and add the TX to
             tx.in_pairs = in_pairs
             # Compute fee
-            tx_fee = (sum(v for hashX, v in tx.in_pairs) -
+            tx.fee = (sum(v for hashX, v in tx.in_pairs) -
                       sum(v for hashX, v in tx.out_pairs))
             txs[hash] = tx
             for hashX, value in itertools.chain(tx.in_pairs, tx.out_pairs):


### PR DESCRIPTION
Also, btw, in this commit https://github.com/kyuupichan/electrumx/commit/b05cc4e78bba4db39e7629f1ad20e82fd1ca86ff, the fee histogram recalculation period was changed from ~30 seconds to ~500 seconds.
Do you think it's that expensive? Would be nice to lower it back.