### PR TITLE
server list: add server to btc testnet

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -617,6 +617,7 @@ class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):
         'hsmithsxurybd7uh.onion t53011 s53012',
         'testnetnode.arihanc.com s t',
         'w3e2orjpiiv2qwem3dw66d7c4krink4nhttngkylglpqe5r22n6n5wid.onion s t',
+        'testnet.qtornado.com s t',
     ]
 
 


### PR DESCRIPTION
From the current btc testnet list, only `hsmiths` is reliably online these days.