### PR TITLE
Fix groestlcoin address parsing

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -2051,6 +2051,10 @@ class Groestlcoin(Coin):
     GENESIS_HASH = ('00000ac5927c594d49cc0bdb81759d0d'
                     'a8297eb614683d3acb62f0703b639023')
     DESERIALIZER = lib_tx.DeserializerGroestlcoin
+    ENCODE_CHECK = partial(Base58.encode_check,
+                           hash_fn=lib_tx.DeserializerGroestlcoin.grshash)
+    DECODE_CHECK = partial(Base58.decode_check,
+                           hash_fn=lib_tx.DeserializerGroestlcoin.grshash)
     TX_COUNT = 115900
     TX_COUNT_HEIGHT = 1601528
     TX_PER_BLOCK = 5
@@ -2065,8 +2069,7 @@ class Groestlcoin(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import groestlcoin_hash
-        return groestlcoin_hash.getHash(header, len(header))
+        return lib_tx.DeserializerGroestlcoin.grshash(header)
 
 
 class GroestlcoinTestnet(Groestlcoin):

--- a/electrumx/lib/tx.py
+++ b/electrumx/lib/tx.py
@@ -417,6 +417,11 @@ class DeserializerBitcoinAtom(DeserializerSegWit):
 
 
 class DeserializerGroestlcoin(DeserializerSegWit):
+    @staticmethod
+    def grshash(data):
+        import groestlcoin_hash
+        return groestlcoin_hash.getHash(data, len(data))
+
     TX_HASH_FN = staticmethod(sha256)
 
 

--- a/tests/lib/test_addresses.py
+++ b/tests/lib/test_addresses.py
@@ -51,6 +51,8 @@ addresses = [
      "2789d58cfa0957d206f025c2af056fc8a77cebb0", "8cc9b11122272bd7b79a50"),
     (coins.Decred, "DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
      "f0b4e85100aee1a996f22915eb3c3f764d53779a", "a03c1a27de9ac3b3122e8d"),
+    (coins.Groestlcoin, "FY7vmDL7FZGACwqVNx5p4fVaGghojWM5AF",
+     "206168f5322583ff37f8e55665a4789ae8963532", "b8cb80b26e8932f5b12a7e"),
 ]
 
 


### PR DESCRIPTION
Is there a better way to conditionally import hash functions for coins without creating static methods?