### PR TITLE
fix block_header_13

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -938,7 +938,7 @@ class ElectrumX(SessionBase):
         '''Return a raw block header as a hexadecimal string.
 
         height: the header's height'''
-        return self.block_header(height)
+        return await self.block_header(height)
 
     async def block_headers(self, start_height, count, cp_height=0):
         '''Return count concatenated block headers as hex for the main chain;


### PR DESCRIPTION
`blockchain.block.header` is not working with protocol version 1.3

log:
```
ERROR:root:task crashed: <Task finished coro=<SessionBase._throttled_request() done, defined at /usr/local/lib/python3.7/site-packages/aiorpcx/session.py:103> exception=ProtocolError(-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/session.py", line 121, in _throttled_request
    message = request.send_result(result)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 651, in _send_result
    message = self._protocol.response_message(result, request_id)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 294, in response_message
    return cls.encode_payload(payload)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 328, in encode_payload
    raise ProtocolError(cls.INTERNAL_ERROR, msg) from None
aiorpcx.jsonrpc.ProtocolError: (-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")
ERROR:TaskGroup:task crashed: <Task finished coro=<SessionBase._throttled_request() done, defined at /usr/local/lib/python3.7/site-packages/aiorpcx/session.py:103> exception=ProtocolError(-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/session.py", line 121, in _throttled_request
    message = request.send_result(result)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 651, in _send_result
    message = self._protocol.response_message(result, request_id)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 294, in response_message
    return cls.encode_payload(payload)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 328, in encode_payload
    raise ProtocolError(cls.INTERNAL_ERROR, msg) from None
aiorpcx.jsonrpc.ProtocolError: (-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")
ERROR:root:task crashed: <Task finished coro=<SessionBase._process_messages() done, defined at /usr/local/lib/python3.7/site-packages/aiorpcx/session.py:81> exception=ProtocolError(-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/session.py", line 90, in _process_messages
    await group.next_result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/curio.py", line 184, in next_result
    return task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/util.py", line 118, in check_task
    task.result()
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/session.py", line 121, in _throttled_request
    message = request.send_result(result)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 651, in _send_result
    message = self._protocol.response_message(result, request_id)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 294, in response_message
    return cls.encode_payload(payload)
  File "/usr/local/lib/python3.7/site-packages/aiorpcx/jsonrpc.py", line 328, in encode_payload
    raise ProtocolError(cls.INTERNAL_ERROR, msg) from None
aiorpcx.jsonrpc.ProtocolError: (-32603, "JSON payload encoding error: {'jsonrpc': '2.0', 'result': <coroutine object ElectrumX.block_header at 0x7fc110cd1248>, 'id': 1}")
```