### PR TITLE
fix max session count limiting

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -575,7 +575,7 @@ class SessionManager(object):
                                 'connections until count drops to {:,d}'
                                 .format(self.max_sessions, self.low_watermark))
             loop = asyncio.get_event_loop()
-            loop.call_soon(self._close_servers(['TCP', 'SSL']))
+            asyncio.run_coroutine_threadsafe(self._close_servers(['TCP', 'SSL']), loop)
         gid = int(session.start_time - self.start_time) // 900
         if self.cur_group.gid != gid:
             self.cur_group = SessionGroup(gid)


### PR DESCRIPTION
Max session count limiting was not working.

```
ERROR:asyncio:Exception in callback SessionManager._close_servers()
handle: <Handle SessionManager._close_servers()>
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/events.py", line 127, in _run
    self._callback(*self._args)
TypeError: 'coroutine' object is not callable
/usr/lib/python3.6/asyncio/base_events.py:284: RuntimeWarning: coroutine 'SessionManager._close_servers' was never awaited
  task = tasks.Task(coro, loop=self)
```