### PR TITLE
BCH: use any-order block processor variant (coin-specific)

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -558,7 +558,6 @@ class BitcoinCashRegtest(BitcoinCashTestnet):
     PEERS = []
     TX_COUNT = 1
     TX_COUNT_HEIGHT = 1
-    BLOCK_PROCESSOR = block_proc.AnyOrderBlockProcessor
 
 
 class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -370,6 +370,7 @@ class BitcoinCash(BitcoinMixin, Coin):
     TX_COUNT = 246362688
     TX_COUNT_HEIGHT = 511484
     TX_PER_BLOCK = 400
+    BLOCK_PROCESSOR = block_proc.AnyOrderBlockProcessor
     PEERS = [
         'electroncash.cascharia.com s50002',
         'bch.electrumx.cash s t',
@@ -541,6 +542,7 @@ class BitcoinTestnetMixin(object):
 class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
     '''Bitcoin Testnet for Bitcoin Cash daemons.'''
     NAME = "BitcoinCash"
+    BLOCK_PROCESSOR = block_proc.AnyOrderBlockProcessor
     PEERS = [
         'electrum-testnet-abc.criptolayer.net s50112',
         'bchtestnet.arihanc.com t53001 s53002',
@@ -556,6 +558,7 @@ class BitcoinCashRegtest(BitcoinCashTestnet):
     PEERS = []
     TX_COUNT = 1
     TX_COUNT_HEIGHT = 1
+    BLOCK_PROCESSOR = block_proc.AnyOrderBlockProcessor
 
 
 class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -729,11 +729,11 @@ class AnyOrderBlockProcessor(BlockProcessor):
         undo_info_append = undo_info.append
         update_touched = self.touched.update
 
-        hashXs_by_tx = [set() for _ in txs]
+        hashXs_by_tx = [list() for _ in txs]
 
         # Add the new UTXOs
         for (tx, tx_hash), hashXs in zip(txs, hashXs_by_tx):
-            add_hashXs = hashXs.add
+            add_hashXs = hashXs.append
             tx_numb = s_pack('<I', tx_num)
 
             for idx, txout in enumerate(tx.outputs):
@@ -748,7 +748,7 @@ class AnyOrderBlockProcessor(BlockProcessor):
         # Spend the inputs
         # A separate for-loop here allows any tx ordering in block.
         for (tx, tx_hash), hashXs in zip(txs, hashXs_by_tx):
-            add_hashXs = hashXs.add
+            add_hashXs = hashXs.append
             for txin in tx.inputs:
                 if txin.is_generation():
                     continue

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -712,6 +712,7 @@ class NamecoinBlockProcessor(BlockProcessor):
 
         return result
 
+
 class AnyOrderBlockProcessor(BlockProcessor):
     '''Modified block processor that allows processing transactions in any
     order. (using outputs-then-inputs algorithm)'''

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -711,3 +711,98 @@ class NamecoinBlockProcessor(BlockProcessor):
         self.db.history.add_unflushed(hashXs_by_tx, self.tx_count - len(txs))
 
         return result
+
+class AnyOrderBlockProcessor(BlockProcessor):
+    '''Modified block processor that allows processing transactions in any
+    order. (using outputs-then-inputs algorithm)'''
+    def advance_txs(self, txs):
+        self.tx_hashes.append(b''.join(tx_hash for tx, tx_hash in txs))
+
+        # Use local vars for speed in the loops
+        undo_info = []
+        tx_num = self.tx_count
+        script_hashX = self.coin.hashX_from_script
+        s_pack = pack
+        put_utxo = self.utxo_cache.__setitem__
+        spend_utxo = self.spend_utxo
+        undo_info_append = undo_info.append
+        update_touched = self.touched.update
+
+        hashXs_by_tx = [set() for _ in txs]
+
+        # Add the new UTXOs
+        for (tx, tx_hash), hashXs in zip(txs, hashXs_by_tx):
+            add_hashXs = hashXs.add
+            tx_numb = s_pack('<I', tx_num)
+
+            for idx, txout in enumerate(tx.outputs):
+                # Get the hashX. Ignore unspendable outputs.
+                hashX = script_hashX(txout.pk_script)
+                if hashX:
+                    add_hashXs(hashX)
+                    put_utxo(tx_hash + s_pack('<H', idx),
+                             hashX + tx_numb + s_pack('<Q', txout.value))
+            tx_num += 1
+
+        # Spend the inputs
+        # A separate for-loop here allows any tx ordering in block.
+        for (tx, tx_hash), hashXs in zip(txs, hashXs_by_tx):
+            add_hashXs = hashXs.add
+            for txin in tx.inputs:
+                if txin.is_generation():
+                    continue
+                cache_value = spend_utxo(txin.prev_hash, txin.prev_idx)
+                undo_info_append(cache_value)
+                add_hashXs(cache_value[:-12])
+
+        # Update touched set for notifications
+        for hashXs in hashXs_by_tx:
+            update_touched(hashXs)
+
+        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
+
+        self.tx_count = tx_num
+        self.db.tx_counts.append(tx_num)
+
+        return undo_info
+
+    def backup_txs(self, txs):
+        undo_info = self.db.read_undo_info(self.height)
+        if undo_info is None:
+            raise ChainError('no undo information found for height {:,d}'
+                             .format(self.height))
+
+        # Use local vars for speed in the loops
+        s_pack = pack
+        put_utxo = self.utxo_cache.__setitem__
+        spend_utxo = self.spend_utxo
+        script_hashX = self.coin.hashX_from_script
+        add_touched = self.touched.add
+        undo_entry_len = 12 + HASHX_LEN
+
+        # Restore coins that had been spent
+        # (may include coins made then spent in this block)
+        n = 0
+        for tx, tx_hash in txs:
+            for txin in tx.inputs:
+                if txin.is_generation():
+                    continue
+                undo_item = undo_info[n:n + undo_entry_len]
+                put_utxo(txin.prev_hash + s_pack('<H', txin.prev_idx),
+                         undo_item)
+                add_touched(undo_item[:-12])
+                n += undo_entry_len
+
+        assert n == len(undo_info)
+
+        # Remove tx outputs made in this block, by spending them.
+        for tx, tx_hash in txs:
+            for idx, txout in enumerate(tx.outputs):
+                hashX = script_hashX(txout.pk_script)
+                if hashX:
+                    # Be careful with unspendable outputs- we didn't save those
+                    # in the first place.
+                    cache_value = spend_utxo(tx_hash, idx)
+                    add_touched(cache_value[:-12])
+
+        self.tx_count -= len(txs)


### PR DESCRIPTION
This is an updated version of #591, modified so that the any-order block processing is coin-specific.

It's perhaps getting a bit late to have any official release with this included, but I thought it would be worthwhile to make the PR to show the concept works well even in coin-specific form. Right now `testnet.imaginary.cash:50002` is running on this commit on top a testnet with CTOR activated early, via BU 1.5.0.0 (@imaginaryusername feel free to correct me).

Depending on how is the aftermath of Nov 15, it may make sense to modify the PR and make two different coins.py entries for the two chains, or, if only one chain survives then either adopt this PR as-is or abandon the PR.

@kyuupichan I can also easily alter this to use lists instead of sets for the hashXs, if memory consumption is still a concern.

(N.b., I have learned my lesson about doing a pull request from master like last time, so no weird contamination commits should show up on this one.)