### PR TITLE
removing electrum3.hachre.de from default peers

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -395,7 +395,6 @@ class BitcoinSegwit(BitcoinMixin, Coin):
         'E-X.not.fyi s t',
         'elec.luggs.co s443',
         'electrum.vom-stausee.de s t',
-        'electrum3.hachre.de s t',
         'electrum.hsmiths.com s t',
         'helicarrier.bauerj.eu s t',
         'hsmiths4fyqlw5xw.onion s t',


### PR DESCRIPTION
Hi @kyuupichan,

there's been a structural change with the servers I oversee and I no longer have the capacity to dedicate to an Electrum server (mostly because of the bitcoind disk space requirements). Thus my server should be removed from the default peers.

Thank you!