### PR TITLE
Viacoin: truncate auxpow from headers

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -680,6 +680,19 @@ class Viacoin(AuxPowMixin, Coin):
         'viax1.bitops.me s t',
     ]
 
+    # Auxpow is redundant in SPV, truncate it from headers
+    @classmethod
+    def block_header(cls, block, height):
+        return super().block_header(block, height)[:cls.BASIC_HEADER_SIZE]
+
+    @classmethod
+    def block(cls, raw_block, height):
+        '''Return a Block namedtuple given a raw block and its height.'''
+        full_header = super().block_header(raw_block, height)
+        header = full_header[:cls.BASIC_HEADER_SIZE]
+        txs = cls.DESERIALIZER(raw_block, start=len(full_header)).read_tx_block()
+        return Block(raw_block, header, txs)
+
 
 class ViacoinTestnet(Viacoin):
     SHORTNAME = "TVI"


### PR DESCRIPTION
Issue: https://github.com/kyuupichan/electrumx/issues/667

One of our devs fixed this issue a few months ago. We had the same issue.
We had our own fork where we truncated the headers
(Done in march 2018: https://github.com/reorder/electrumx/commit/0bfadbf27c4854aa083b97f6ef7ee34e1c770176)

So https://github.com/kyuupichan/electrumx/issues/667#issuecomment-447657576
This should be the fix. 
