### PR TITLE
fix error handling for RPC params re non_negative_integer

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -56,7 +56,7 @@ def non_negative_integer(value):
         value = int(value)
         if value >= 0:
             return value
-    except ValueError:
+    except (ValueError, TypeError):
         pass
     raise RPCError(BAD_REQUEST,
                    f'{value} should be a non-negative integer')
@@ -1106,6 +1106,7 @@ class ElectrumX(SessionBase):
         height: the height of the block it is in
         '''
         assert_tx_hash(tx_hash)
+        height = non_negative_integer(height)
         block_hash, tx_hashes = await self._block_hash_and_tx_hashes(height)
         try:
             pos = tx_hashes.index(tx_hash)
@@ -1120,6 +1121,7 @@ class ElectrumX(SessionBase):
         a block height and position in the block.
         '''
         tx_pos = non_negative_integer(tx_pos)
+        height = non_negative_integer(height)
         if merkle not in (True, False):
             raise RPCError(BAD_REQUEST, f'"merkle" must be a boolean')
 


### PR DESCRIPTION
This fixes some minor error handling issues re malformed RPC params.

-----

`printf '{"id": 1, "method": "server.version", "params": ["testing", "1.4"]}\n{"id": 2, "method": "blockchain.transaction.get_merkle", "params": ["6bab865751523d13c14528a9f1c019cd28e0a1e2efb80cfa17a35cd806a1012d", "0"]}\n' | nc 127.0.0.1 50001`
```
ERROR:ElectrumX:[3] exception handling Request('blockchain.transaction.get_merkle', ['6bab865751523d13c14528a9f1c019cd28e0a1e2efb80cfa17a35cd806a1012d', '0'])
Traceback (most recent call last):
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 1111, in transaction_merkle
    pos = tx_hashes.index(tx_hash)
ValueError: '6bab865751523d13c14528a9f1c019cd28e0a1e2efb80cfa17a35cd806a1012d' is not in list

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/.local/lib/python3.6/site-packages/aiorpcx/session.py", line 461, in _throttled_request
    result = await self.handle_request(request)
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 688, in handle_request
    return await coro
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 1113, in transaction_merkle
    raise RPCError(BAD_REQUEST, f'tx hash {tx_hash} not in '
ValueError: Unknown format code 'd' for object of type 'str'
```

-----
`printf '{"id": 1, "method": "server.version", "params": ["testing", "1.4"]}\n{"id": 2, "method": "blockchain.estimatefee", "params": [null]}\n' | nc 127.0.0.1 50001`

```
ERROR:ElectrumX:[5] exception handling Request('blockchain.estimatefee', [None])
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.6/site-packages/aiorpcx/session.py", line 461, in _throttled_request
    result = await self.handle_request(request)
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 688, in handle_request
    return await coro
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 1004, in estimatefee
    number = non_negative_integer(number)
  File "/home/user/wspace/electrumx/electrumx/server/session.py", line 56, in non_negative_integer
    value = int(value)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```