### PR TITLE
dash_tx: serialize port as big endian

### DIFF
--- a/electrumx/lib/tx.py
+++ b/electrumx/lib/tx.py
@@ -34,6 +34,7 @@ from electrumx.lib.hash import sha256, double_sha256, hash_to_hex_str
 from electrumx.lib.script import OpCodes
 from electrumx.lib.util import (
     unpack_le_int32_from, unpack_le_int64_from, unpack_le_uint16_from,
+    unpack_be_uint16_from,
     unpack_le_uint32_from, unpack_le_uint64_from, pack_le_int32, pack_varint,
     pack_le_uint32, pack_le_int64, pack_varbytes,
 )
@@ -191,6 +192,11 @@ class Deserializer(object):
 
     def _read_le_uint16(self):
         result, = unpack_le_uint16_from(self.binary, self.cursor)
+        self.cursor += 2
+        return result
+
+    def _read_be_uint16(self):
+        result, = unpack_be_uint16_from(self.binary, self.cursor)
         self.cursor += 2
         return result
 

--- a/electrumx/lib/tx_dash.py
+++ b/electrumx/lib/tx_dash.py
@@ -30,7 +30,8 @@ from collections import namedtuple
 
 from electrumx.lib.tx import Deserializer
 from electrumx.lib.util import (pack_le_uint16, pack_le_int32, pack_le_uint32,
-                                pack_le_int64, pack_varint, pack_varbytes)
+                                pack_le_int64, pack_varint, pack_varbytes,
+                                pack_be_uint16)
 
 
 # https://github.com/dashpay/dips/blob/master/dip-0002.md
@@ -86,7 +87,7 @@ class DashProRegTx(namedtuple("DashProRegTx",
             pack_le_uint16(self.mode) +                 # mode
             self.collateralOutpoint.serialize() +       # collateralOutpoint
             self.ipAddress +                            # ipAddress
-            pack_le_uint16(self.port) +                 # port
+            pack_be_uint16(self.port) +                 # port
             self.KeyIdOwner +                           # KeyIdOwner
             self.PubKeyOperator +                       # PubKeyOperator
             self.KeyIdVoting +                          # KeyIdVoting
@@ -104,7 +105,7 @@ class DashProRegTx(namedtuple("DashProRegTx",
             deser._read_le_uint16(),                    # mode
             deser._read_outpoint(),                     # collateralOutpoint
             deser._read_nbytes(16),                     # ipAddress
-            deser._read_le_uint16(),                    # port
+            deser._read_be_uint16(),                    # port
             deser._read_nbytes(20),                     # KeyIdOwner
             deser._read_nbytes(48),                     # PubKeyOperator
             deser._read_nbytes(20),                     # KeyIdVoting
@@ -129,7 +130,7 @@ class DashProUpServTx(namedtuple("DashProUpServTx",
             pack_le_uint16(self.version) +              # version
             self.proTxHash +                            # proTxHash
             self.ipAddress +                            # ipAddress
-            pack_le_uint16(self.port) +                 # port
+            pack_be_uint16(self.port) +                 # port
             pack_varbytes(self.scriptOperatorPayout) +  # scriptOperatorPayout
             self.inputsHash +                           # inputsHash
             self.payloadSig                             # payloadSig
@@ -141,7 +142,7 @@ class DashProUpServTx(namedtuple("DashProUpServTx",
             deser._read_le_uint16(),                    # version
             deser._read_nbytes(32),                     # proTxHash
             deser._read_nbytes(16),                     # ipAddress
-            deser._read_le_uint16(),                    # port
+            deser._read_be_uint16(),                    # port
             deser._read_varbytes(),                     # scriptOperatorPayout
             deser._read_nbytes(32),                     # inputsHash
             deser._read_nbytes(96)                      # payloadSig

--- a/tests/lib/test_tx_dash.py
+++ b/tests/lib/test_tx_dash.py
@@ -217,7 +217,7 @@ def test_dash_tx_pro_reg_tx():
     assert extra.collateralOutpoint.index == 1
     assert len(extra.ipAddress) == 16
     assert extra.ipAddress == bfh('00000000000000000000ffff12ca34aa')
-    assert extra.port == 12149
+    assert extra.port == 29999
     assert len(extra.KeyIdOwner) == 20
     assert extra.KeyIdOwner == bfh(
         '2b3edeed6842db1f59cf35de1ab5721094f049d0')
@@ -255,7 +255,7 @@ def test_dash_tx_pro_up_serv_tx():
         '3c6dca244f49f19d3f09889753ffff1fec5bb8f9f5bd5bc09dabd999da21198f')
     assert len(extra.ipAddress) == 16
     assert extra.ipAddress == bfh('00000000000000000000ffff5fb73580')
-    assert extra.port == 4391
+    assert extra.port == 10001
     assert extra.scriptOperatorPayout == bfh(
         '76a91421851058431a7d722e8e8dd9509e7f2b8e7042ec88ac')
     assert len(extra.inputsHash) == 32


### PR DESCRIPTION
Fix serialization/deserialization of masternode service port. Must be in network byte order.