### PR TITLE
Increase MAX_SEND for AuxPoW chains

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -228,9 +228,10 @@ raise them.
 .. envvar:: MAX_SEND
 
   The maximum size of a response message to send over the wire, in
-  bytes.  Defaults to 1,000,000.  Values smaller than 350,000 are
-  taken as 350,000 because standard Electrum protocol header "chunk"
-  requests are almost that large.
+  bytes.  Defaults to 1,000,000 (except for AuxPoW coins, which default
+  to 10,000,000).  Values smaller than 350,000 are taken as 350,000
+  because standard Electrum protocol header "chunk" requests are almost
+  that large.
 
   The Electrum protocol has a flaw in that address histories must be
   served all at once or not at all, an obvious avenue for abuse.

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -68,6 +68,7 @@ class Coin(object):
     BASIC_HEADER_SIZE = 80
     STATIC_BLOCK_HEADERS = True
     SESSIONCLS = ElectrumX
+    DEFAULT_MAX_SEND = 1000000
     DESERIALIZER = lib_tx.Deserializer
     DAEMON = daemon.Daemon
     BLOCK_PROCESSOR = block_proc.BlockProcessor
@@ -259,6 +260,10 @@ class AuxPowMixin(object):
     STATIC_BLOCK_HEADERS = False
     DESERIALIZER = lib_tx.DeserializerAuxPow
     SESSIONCLS = AuxPoWElectrumX
+    # AuxPoW headers are significantly larger, so the DEFAULT_MAX_SEND from
+    # Bitcoin is insufficient.  In Namecoin mainnet, 5 MB wasn't enough to
+    # sync, while 10 MB worked fine.
+    DEFAULT_MAX_SEND = 10000000
 
     @classmethod
     def header_hash(cls, header):

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -68,7 +68,7 @@ class Env(EnvBase):
         # The electrum client takes the empty string as unspecified
         self.donation_address = self.default('DONATION_ADDRESS', '')
         # Server limits to help prevent DoS
-        self.max_send = self.integer('MAX_SEND', 1000000)
+        self.max_send = self.integer('MAX_SEND', self.coin.DEFAULT_MAX_SEND)
         self.max_subs = self.integer('MAX_SUBS', 250000)
         self.max_sessions = self.sane_max_sessions()
         self.max_session_subs = self.integer('MAX_SESSION_SUBS', 50000)


### PR DESCRIPTION
AuxPoW headers are significantly larger than the headers in Bitcoin, so the current default MAX_SEND of 1 MB is insufficient.  In Namecoin mainnet, 5 MB wasn't enough to sync, while 10 MB worked fine.  I suspect that most other AuxPoW chains will be similar, so 10 MB seems like a decent default for AuxPoW chains.