### PR TITLE
Blacklist logic:

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -345,6 +345,11 @@ some of this.
   will autodetect any proxy running on the usual ports 9050 (Tor),
   9150 (Tor browser bundle) and 1080 (socks).
 
+.. envvar:: BLACKLIST_URL
+
+  URL to retrieve a list of blacklisted peers.
+
+
 
 Server Advertising
 ==================

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -75,6 +75,10 @@ class Env(EnvBase):
         self.bandwidth_limit = self.integer('BANDWIDTH_LIMIT', 2000000)
         self.session_timeout = self.integer('SESSION_TIMEOUT', 600)
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
+        self.blacklist_url = self.default('BLACKLIST_URL', None)
+        # temporary default
+        if self.blacklist_url is None and self.coin.NAME == 'BitcoinSegwit':
+            self.blacklist_url = 'https://electrum.org/blacklist.json'
 
         # Identities
         clearnet_identity = self.clearnet_identity()

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -714,6 +714,7 @@ class ElectrumX(SessionBase):
         self.sv_seen = False
         self.mempool_statuses = {}
         self.set_request_handlers(self.PROTOCOL_MIN)
+        self.is_peer = False
 
     @classmethod
     def protocol_min_max_strings(cls):
@@ -812,11 +813,12 @@ class ElectrumX(SessionBase):
 
     async def add_peer(self, features):
         '''Add a peer (but only if the peer resolves to the source).'''
+        self.is_peer = True
         return await self.peer_mgr.on_add_peer(features, self.peer_address())
 
     async def peers_subscribe(self):
         '''Return the server peers as a list of (ip, host, details) tuples.'''
-        return self.peer_mgr.on_peers_subscribe(self.is_tor())
+        return self.peer_mgr.on_peers_subscribe(self.is_tor(), self.is_peer)
 
     async def address_status(self, hashX):
         '''Returns an address status.


### PR DESCRIPTION
* do not return blacklisted peers to clients
* blacklist is retrieved from BLACKLIST_URL
* blacklist is refreshed every 10 minutes
* for BitcoinSegwit, BLACKLIST_URL defaults to https://electrum.org/blacklist.json