### PR TITLE
[DashElectrumX] prevent size change of self.mns

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1319,7 +1319,7 @@ class DashElectrumX(ElectrumX):
     async def notify(self, touched, height_changed):
         '''Notify the client about changes in masternode list.'''
         await super().notify(touched, height_changed)
-        for mn in self.mns:
+        for mn in self.mns.copy():
             status = await self.daemon_request('masternode_list',
                                                ['status', mn])
             await self.send_notification('masternode.subscribe',


### PR DESCRIPTION
send_notification adds the retreived collateral to self.mns during masternode.subscribe, this can issue a runtime error because size of self.mns changes during iteration.
Reproduce: issue multiple masternode.subscribe (with valid and invalid collaterals) during the same session.