### PR TITLE
peers: mark blacklisted peers bad

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -818,7 +818,7 @@ class ElectrumX(SessionBase):
 
     async def peers_subscribe(self):
         '''Return the server peers as a list of (ip, host, details) tuples.'''
-        return self.peer_mgr.on_peers_subscribe(self.is_tor(), self.is_peer)
+        return self.peer_mgr.on_peers_subscribe(self.is_tor())
 
     async def address_status(self, hashX):
         '''Returns an address status.


### PR DESCRIPTION
My server has ~9.5k total peers, of which 1.5k is "good", on BTC mainnet.
I also observe some general slowness and fewer than usual session count; which I am not sure if related to the absurd peer count, but it might be.

I think blacklisted peers should be marked bad, so we don't gossip about them to other peers, and we don't keep monitoring them; which is what this PR does.

@ecdsa what do you think?