### PR TITLE
peers: force retry blacklisted active peers after fetching blacklist

### DIFF
--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -146,6 +146,11 @@ class PeerManager(object):
                 self.logger.info(f'blacklist from {url} has {len(self.blacklist)} entries')
             except Exception as e:
                 self.logger.error(f'could not retrieve blacklist from {url}: {e}')
+            else:
+                # Got new blacklist. Now check our current peers against it
+                for peer in self.peers:
+                    if self._is_blacklisted(peer.host):
+                        peer.retry_event.set()
             await sleep(600)
 
     def _is_blacklisted(self, host):


### PR DESCRIPTION
implements https://github.com/kyuupichan/electrumx/issues/756#issuecomment-472550913
to address https://github.com/kyuupichan/electrumx/pull/753#issuecomment-471321214

So, after fetching the blacklist, force a rerun of `_should_drop_peer` and `_verify_peer` for each of our current peers that are in the newly fetched blacklist. This will ensure that blacklisted peers get marked bad immediately (instead of up to 24 hours later).