### PR TITLE
crash old clients

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -268,7 +268,7 @@ class Coin(object):
         return h
 
     @classmethod
-    def upgrade_required(cls, client_ver):
+    def warn_old_client_on_tx_broadcast(cls, client_ver):
         return False
 
 
@@ -405,7 +405,7 @@ class BitcoinCash(BitcoinMixin, Coin):
     BLOCK_PROCESSOR = block_proc.LTORBlockProcessor
 
     @classmethod
-    def upgrade_required(cls, client_ver):
+    def warn_old_client_on_tx_broadcast(cls, client_ver):
         if client_ver < (3, 3, 4):
             return ('<br/><br/>'
                     'Your transaction was successfully broadcast.<br/><br/>'
@@ -439,7 +439,7 @@ class BitcoinSegwit(BitcoinMixin, Coin):
     ]
 
     @classmethod
-    def upgrade_required(cls, client_ver):
+    def warn_old_client_on_tx_broadcast(cls, client_ver):
         if client_ver < (3, 3, 3):
             return ('<br/><br/>'
                     'Your transaction was successfully broadcast.<br/><br/>'
@@ -614,7 +614,7 @@ class BitcoinCashTestnet(BitcoinTestnetMixin, Coin):
     BLOCK_PROCESSOR = block_proc.LTORBlockProcessor
 
     @classmethod
-    def upgrade_required(cls, client_ver):
+    def warn_old_client_on_tx_broadcast(cls, client_ver):
         if client_ver < (3, 3, 4):
             return ('<br/><br/>'
                     'Your transaction was successfully broadcast.<br/><br/>'
@@ -649,7 +649,7 @@ class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):
     ]
 
     @classmethod
-    def upgrade_required(cls, client_ver):
+    def warn_old_client_on_tx_broadcast(cls, client_ver):
         if client_ver < (3, 3, 3):
             return ('<br/><br/>'
                     'Your transaction was successfully broadcast.<br/><br/>'

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -47,7 +47,8 @@ import electrumx.lib.tx_dash as lib_tx_dash
 import electrumx.server.block_processor as block_proc
 import electrumx.server.daemon as daemon
 from electrumx.server.session import (ElectrumX, DashElectrumX,
-                                      SmartCashElectrumX, AuxPoWElectrumX)
+                                      SmartCashElectrumX, AuxPoWElectrumX,
+                                      BitcoinSegwitElectrumX)
 
 
 Block = namedtuple("Block", "raw header transactions")
@@ -419,6 +420,7 @@ class BitcoinCash(BitcoinMixin, Coin):
 class BitcoinSegwit(BitcoinMixin, Coin):
     NAME = "BitcoinSegwit"
     DESERIALIZER = lib_tx.DeserializerSegWit
+    SESSIONCLS = BitcoinSegwitElectrumX
     MEMPOOL_HISTOGRAM_REFRESH_SECS = 120
     TX_COUNT = 318337769
     TX_COUNT_HEIGHT = 524213
@@ -638,6 +640,7 @@ class BitcoinSegwitTestnet(BitcoinTestnetMixin, Coin):
     '''Bitcoin Testnet for Core bitcoind >= 0.13.1.'''
     NAME = "BitcoinSegwit"
     DESERIALIZER = lib_tx.DeserializerSegWit
+    SESSIONCLS = BitcoinSegwitElectrumX
     PEERS = [
         'electrum.akinbo.org s t',
         'he36kyperp3kbuxu.onion s t',

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1148,7 +1148,7 @@ class ElectrumX(SessionBase):
             self.txs_sent += 1
             client_ver = util.protocol_tuple(self.client)
             if client_ver != (0, ):
-                msg = self.coin.upgrade_required(client_ver)
+                msg = self.coin.warn_old_client_on_tx_broadcast(client_ver)
                 if msg:
                     self.logger.info(f'sent tx: {hex_hash}. and warned user to upgrade their '
                                      f'client from {self.client}')


### PR DESCRIPTION
On the BTC chain, exploit a DOS vulnerability in old Electrum clients, to kill their network thread and make them unusable. This should force users of old clients that are vulnerable to the transaction-broadcast phishing attack to upgrade their client.

Note:
This is expected to negatively affect users of some Linux distros that are stuck on old client versions, such as Debian and Tails. These users should manually download upstream Electrum. The [easiest upgrade path](https://github.com/spesmilo/electrum-docs/blob/master/faq.rst#electrum-requires-recent-python-my-linux-distribution-does-not-yet-have-it-what-now) is probably to get the appimage from electrum.org.