### PR TITLE
peers: case insensitive blacklist

### DIFF
--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -142,7 +142,7 @@ class PeerManager(object):
             try:
                 async with session.get(url) as response:
                     r = await response.text()
-                self.blacklist = set(json.loads(r))
+                self.blacklist = set([entry.lower() for entry in json.loads(r)])
                 self.logger.info(f'blacklist from {url} has {len(self.blacklist)} entries')
             except Exception as e:
                 self.logger.error(f'could not retrieve blacklist from {url}: {e}')
@@ -154,6 +154,7 @@ class PeerManager(object):
             await sleep(600)
 
     def _is_blacklisted(self, host):
+        host = host.lower()
         return any(item in self.blacklist
                    for item in (host, '*.' + '.'.join(host.split('.')[-2:])))
 


### PR DESCRIPTION
Fixes hosts bypassing the blacklist by varying capitalization in their hostnames.
