### PR TITLE
local rpc: new field for getinfo: "sessions_with_subs"

### DIFF
--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -84,6 +84,7 @@ A typical result is as follows (with annotated comments)::
     "pid": 85861,                  # Server's process ID
     "requests": 0,                 # Unprocessed requests across all sessions
     "sessions": 43,                # Total number of sessions
+    "sessions_with_subs": 4,       # Number of sessions with history subscriptions
     "subs": 84,                    # Script hash subscriptions across all sessions
     "txs_sent": 4,                 # Transactions sent since server started
     "uptime": "06h 48m 00s"        # Time since server started

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -293,6 +293,7 @@ class SessionManager(object):
             'peers': self.peer_mgr.info(),
             'requests': sum(s.count_pending_items() for s in self.sessions),
             'sessions': self.session_count(),
+            'sessions_with_subs': self.session_count_with_subs(),
             'subs': self._sub_count(),
             'txs_sent': self.txs_sent,
             'uptime': util.formatted_time(time.time() - self.start_time),
@@ -519,6 +520,11 @@ class SessionManager(object):
     def session_count(self):
         '''The number of connections that we've sent something to.'''
         return len(self.sessions)
+
+    def session_count_with_subs(self):
+        '''The number of connections that have at least one hashX subscription.'''
+        return sum(len(session.hashX_subs) > 0 for session in self.sessions
+                   if hasattr(session, 'hashX_subs'))
 
     async def daemon_request(self, method, *args):
         '''Catch a DaemonError and convert it to an RPCError.'''


### PR DESCRIPTION
I think it would be interesting to see not just the number of sessions (~connected clients), but also how many of those have subscribed to scripthashes (~uses this server as main server).