### PR TITLE
WIP: naive per-IP session-resource limiting

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -274,6 +274,21 @@ raise them.
   Bandwidth usage is gradually reduced over time by "refunding" a
   proportional part of the limit every now and then.
 
+.. envvar:: RESOURCE_USAGE_LIMIT
+
+  Per IP address periodic resource usage limit.
+  Very similar to :envvar:`BANDWIDTH_LIMIT`, with a notable difference
+  being that this limit is based on the IP address of the session and
+  is persisted (only in memory) across reconnects.
+
+  Requests made by sessions incur costs. This cost is a naive heuristic
+  that tries to correlate with the CPU and DISK I/O usage of the request.
+
+  The time period is one day. The default resource limit is coin-specific.
+  For BTC, it is 30000. Set to zero for "unlimited".
+
+  See the :ref:`res_usage` RPC command.
+
 .. envvar:: SESSION_TIMEOUT
 
   An integer number of seconds defaulting to 600.  Sessions with no

--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -115,6 +115,27 @@ Low-priority sessions have their requests served after higher priority
 sessions.  ElectrumX will start delaying responses to a session if it
 becomes sufficiently deprioritized.
 
+res_usage
+---------
+
+Return the state of the internal per-session-IP resource limit tracker.
+As a form of DOS limit, requests made by sessions have costs.
+These costs are incurred by the IP address of the session.
+The result is sorted in decreasing order of costs::
+
+  $ electrumx_rpc res_usage
+  [
+    [
+        "41.200.217.53/32",
+        3624050.0391892944
+    ],
+    [
+        "187.39.240.113/32",
+        3599832.8948473367
+    ],
+    ...
+  ]
+
 groups
 ------
 

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -86,6 +86,7 @@ class Coin(object):
     PEER_DEFAULT_PORTS = {'t': '50001', 's': '50002'}
     PEERS = []
     BLACKLIST_URL = None
+    RESOURCE_USAGE_LIMIT = 0
 
     @classmethod
     def lookup_coin_class(cls, name, net):
@@ -427,6 +428,7 @@ class BitcoinSegwit(BitcoinMixin, Coin):
     TX_COUNT_HEIGHT = 524213
     TX_PER_BLOCK = 1400
     BLACKLIST_URL = 'https://electrum.org/blacklist.json'
+    RESOURCE_USAGE_LIMIT = 30_000
     PEERS = [
         'btc.smsys.me s995',
         'E-X.not.fyi s t',

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -72,6 +72,7 @@ class Env(EnvBase):
         self.max_sessions = self.sane_max_sessions()
         self.max_session_subs = self.integer('MAX_SESSION_SUBS', 50000)
         self.bandwidth_limit = self.integer('BANDWIDTH_LIMIT', 2000000)
+        self.res_usage_limit = self.integer('RESOURCE_USAGE_LIMIT', self.coin.RESOURCE_USAGE_LIMIT)
         self.session_timeout = self.integer('SESSION_TIMEOUT', 600)
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
         self.blacklist_url = self.default('BLACKLIST_URL', self.coin.BLACKLIST_URL)

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1205,9 +1205,11 @@ class ElectrumX(SessionBase):
 
         raw_tx: the raw transaction as a hexadecimal string'''
         # This returns errors as JSON RPC errors, as is natural
+        self.inc_resource_usage(5)
         try:
             hex_hash = await self.session_mgr.broadcast_transaction(raw_tx)
         except DaemonError as e:
+            self.inc_resource_usage(50)
             error, = e.args
             message = error['message']
             self.logger.info(f'error sending transaction: {message}')

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -736,6 +736,8 @@ class SessionBase(RPCSession):
         bucket = self._bucket_for_resource_usage()
         res_usage = self.session_mgr.res_usage_of_ip[bucket]
         sleep_time = res_usage / self.res_usage_limit - 1
+        if sleep_time > 30:
+            raise FinalRPCError(BAD_REQUEST, 'session is using too much resources')
         if sleep_time > 0:
             await sleep(sleep_time)
 

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -24,6 +24,7 @@ simple_commands = {
     'groups': 'Print current session groups',
     'peers': 'Print information about peer servers for the same coin',
     'sessions': 'Print information about client sessions',
+    'res_usage': 'Dump internal tracker of resource usage of IPs',
     'stop': 'Shut down the server cleanly',
 }
 


### PR DESCRIPTION
> Per IP address periodic resource usage limit.
  Very similar to :envvar:`BANDWIDTH_LIMIT`, with a notable difference
  being that this limit is based on the IP address of the session and
  is persisted (only in memory) across reconnects.
> 
> Requests made by sessions incur costs. This cost is a naive heuristic
  that tries to correlate with the CPU and DISK I/O usage of the request.
> 
> The time period is one day. The default resource limit is coin-specific.
  For BTC, it is 30000. Set to zero for "unlimited".

"WIP" mainly because I am still fiddling around with it a bit;
and I am not even sure whether this is the right approach...
Made the PR so that it can get feedback and others can test it too.