### PR TITLE
Change peer list refresh / stale timeout from 24 hours to 1 hour

### DIFF
--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -25,7 +25,7 @@ from electrumx.lib.peer import Peer
 from electrumx.lib.util import class_logger, protocol_tuple
 
 PEER_GOOD, PEER_STALE, PEER_NEVER, PEER_BAD = range(4)
-STALE_SECS = 24 * 3600
+STALE_SECS = 3600
 WAKEUP_SECS = 300
 PEER_ADD_PAUSE = 600
 

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -25,7 +25,7 @@ from electrumx.lib.peer import Peer
 from electrumx.lib.util import class_logger, protocol_tuple
 
 PEER_GOOD, PEER_STALE, PEER_NEVER, PEER_BAD = range(4)
-STALE_SECS = 3600
+STALE_SECS = 3 * 3600
 WAKEUP_SECS = 300
 PEER_ADD_PAUSE = 600
 


### PR DESCRIPTION
With the current DDoS attack the availability of servers changes often throughout the day (DDoS intensity, server load, server reboots) - well within 24 hours. Currently no server has an accurate reachable peer list since a newly unreachable server is still served as reachable for 24 hours due to the peer reachability / staleness test only being done once a day then retried multiple times before finally forgetting unreachable peers. 

Changing to hourly would help give clients a quicker syncing (and therefore better) experience since they wouldn't be trying to connect to servers that may be unreachable for up to 23 hours prior (due to server overload / DDoS, etc) with only a negligible increase in server load hourly.