### PR TITLE
aiorpcX 0.17 fixes

### DIFF
--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -472,14 +472,14 @@ class PeerManager:
         '''Add a peer passed by the admin over LocalRPC.'''
         await self._note_peers([Peer.from_real_name(real_name, 'RPC')])
 
-    async def on_add_peer(self, features, source_info):
+    async def on_add_peer(self, features, source_addr):
         '''Add a peer (but only if the peer resolves to the source).'''
         if self.env.peer_discovery != self.env.PD_ON:
             return False
-        if not source_info:
+        if not source_addr:
             self.logger.info('ignored add_peer request: no source info')
             return False
-        source = source_info[0]
+        source = str(source_addr.host)
         peers = Peer.peers_from_features(features, source)
         if not peers:
             self.logger.info('ignored add_peer request: no peers given')
@@ -557,10 +557,10 @@ class PeerManager:
 
         return [peer.to_tuple() for peer in peers]
 
-    def proxy_peername(self):
-        '''Return the peername of the proxy, if there is a proxy, otherwise
+    def proxy_address(self):
+        '''Return the NetAddress of the proxy, if there is a proxy, otherwise
         None.'''
-        return self.proxy.peername if self.proxy else None
+        return self.proxy.address if self.proxy else None
 
     def rpc_data(self):
         '''Peer data for the peers RPC method.'''

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -989,7 +989,7 @@ class ElectrumX(SessionBase):
         '''Add a peer (but only if the peer resolves to the source).'''
         self.is_peer = True
         self.bump_cost(100.0)
-        return await self.peer_mgr.on_add_peer(features, self.remote_address_string(for_log=False))
+        return await self.peer_mgr.on_add_peer(features, self.remote_address())
 
     async def peers_subscribe(self):
         '''Return the server peers as a list of (ip, host, details) tuples.'''
@@ -1169,10 +1169,10 @@ class ElectrumX(SessionBase):
     def is_tor(self):
         '''Try to detect if the connection is to a tor hidden service we are
         running.'''
-        peername = self.peer_mgr.proxy_peername()
-        if not peername:
+        proxy_address = self.peer_mgr.proxy_address()
+        if not proxy_address:
             return False
-        return self.remote_address().host == peername[0]
+        return self.remote_address().host == proxy_address.host
 
     async def replaced_banner(self, banner):
         network_info = await self.daemon_request('getnetworkinfo')


### PR DESCRIPTION
Peer manager's `proxy_peername()` to `proxy_address()` to fix session's `is_tor()` check

also use `NetAddress` for `on_add_peer()`