### PR TITLE
Bump default cost limits for AuxPoW coins

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -256,9 +256,12 @@ raise them.
 .. envvar:: REQUEST_SLEEP
 .. envvar:: INITIAL_CONCURRENT
 
-  All values are integers. :envvar:`COST_SOFT_LIMIT` defaults to :const:`1,000`,
-  :envvar:`COST_HARD_LIMIT` to :const:`10,000`, :envvar:`REQUEST_SLEEP` to :const:`2,500`
-  milliseconds, and :envvar:`INITIAL_CONCURRENT` to :const:`10` concurrent requests.
+  All values are integers. For most coins, :envvar:`COST_SOFT_LIMIT` defaults
+  to :const:`1,000`, :envvar:`COST_HARD_LIMIT` to :const:`10,000`,
+  :envvar:`REQUEST_SLEEP` to :const:`2,500` milliseconds, and
+  :envvar:`INITIAL_CONCURRENT` to :const:`10` concurrent requests.  AuxPoW
+  coins are the same, except that :envvar:`COST_SOFT_LIMIT` defaults to
+  :const:`10,000` and :envvar:`COST_HARD_LIMIT` to :const:`100,000`.
 
   The server prices each request made to it based upon an estimate of the resources needed
   to process it.  Factors include whether the request uses bitcoind, how much bandwidth

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -69,6 +69,8 @@ class Coin(object):
     STATIC_BLOCK_HEADERS = True
     SESSIONCLS = ElectrumX
     DEFAULT_MAX_SEND = 1000000
+    DEFAULT_COST_SOFT_LIMIT = 1000
+    DEFAULT_COST_HARD_LIMIT = 10000
     DESERIALIZER = lib_tx.Deserializer
     DAEMON = daemon.Daemon
     BLOCK_PROCESSOR = block_proc.BlockProcessor
@@ -271,10 +273,12 @@ class AuxPowMixin(object):
     STATIC_BLOCK_HEADERS = False
     DESERIALIZER = lib_tx.DeserializerAuxPow
     SESSIONCLS = AuxPoWElectrumX
-    # AuxPoW headers are significantly larger, so the DEFAULT_MAX_SEND from
-    # Bitcoin is insufficient.  In Namecoin mainnet, 5 MB wasn't enough to
-    # sync, while 10 MB worked fine.
+    # AuxPoW headers are significantly larger, so the default resource usage
+    # limits from Bitcoin are insufficient.  In Namecoin mainnet, 5 MB MAX_SEND
+    # wasn't enough to sync, while 10 MB worked fine.
     DEFAULT_MAX_SEND = 10000000
+    DEFAULT_COST_SOFT_LIMIT = 10000
+    DEFAULT_COST_HARD_LIMIT = 100000
 
     @classmethod
     def header_hash(cls, header):

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -70,8 +70,8 @@ class Env(EnvBase):
         # Server limits to help prevent DoS
         self.max_send = self.integer('MAX_SEND', self.coin.DEFAULT_MAX_SEND)
         self.max_sessions = self.sane_max_sessions()
-        self.cost_soft_limit = self.integer('COST_SOFT_LIMIT', 1000)
-        self.cost_hard_limit = self.integer('COST_HARD_LIMIT', 10000)
+        self.cost_soft_limit = self.integer('COST_SOFT_LIMIT', self.coin.DEFAULT_COST_SOFT_LIMIT)
+        self.cost_hard_limit = self.integer('COST_HARD_LIMIT', self.coin.DEFAULT_COST_HARD_LIMIT)
         self.bw_unit_cost = self.integer('BANDWIDTH_UNIT_COST', 5000)
         self.initial_concurrent = self.integer('INITIAL_CONCURRENT', 10)
         self.request_sleep = self.integer('REQUEST_SLEEP', 2500)


### PR DESCRIPTION
This is necessary because AuxPoW coins' headers are substantially larger, so the increased bandwidth usage during header download was hitting the default limits.