### PR TITLE
Add drop_peer RPC command

### DIFF
--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -26,6 +26,15 @@ connection attempt.  This command takes a single argument: the peer's
   $ electrumx_rpc add_peer "ecdsa.net v1.0 s110 t"
   "peer 'ecdsa.net v1.0 s110 t' added"
 
+drop_peer
+---------
+
+Drop a peer from the peers list, if found.  This command takes a single
+argument: the peer's hostname (or IP) as it appears in the list::
+
+  $ electrumx_rpc drop_peer ecdsa.net
+  "peer 'ecdsa.net' forgotten"
+
 daemon_url
 ----------
 

--- a/electrumx/server/peers.py
+++ b/electrumx/server/peers.py
@@ -473,6 +473,17 @@ class PeerManager:
         '''Add a peer passed by the admin over LocalRPC.'''
         await self._note_peers([Peer.from_real_name(real_name, 'RPC')])
 
+    def drop_localRPC_peer(self, host):
+        '''Drop a peer passed by the admin over LocalRPC.'''
+        dropped = False
+        for peer in self.peers:
+            if peer.host == host:
+                self.logger.info(f'forgetting {peer}')
+                self.peers.discard(peer)
+                dropped = True
+                break
+        return dropped
+
     async def on_add_peer(self, features, source_addr):
         '''Add a peer (but only if the peer resolves to the source).'''
         if self.env.peer_discovery != self.env.PD_ON:

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -149,8 +149,8 @@ class SessionManager(object):
         self.session_event = Event()
 
         # Set up the RPC request handlers
-        cmds = ('add_peer daemon_url disconnect getinfo groups log peers '
-                'query reorg sessions stop'.split())
+        cmds = ('add_peer drop_peer daemon_url disconnect getinfo groups log '
+                'peers query reorg sessions stop'.split())
         LocalRPC.request_handlers = {cmd: getattr(self, 'rpc_' + cmd)
                                      for cmd in cmds}
 
@@ -397,6 +397,14 @@ class SessionManager(object):
         '''
         await self.peer_mgr.add_localRPC_peer(real_name)
         return "peer '{}' added".format(real_name)
+
+    async def rpc_drop_peer(self, host):
+        '''Drop a peer.
+
+        host: "bch.electrumx.cash" for example
+        '''
+        dropped = self.peer_mgr.drop_localRPC_peer(host)
+        return "peer '{}' {}".format(host, 'forgotten' if dropped else 'not found')
 
     async def rpc_disconnect(self, session_ids):
         '''Disconnect sesssions.

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -41,6 +41,14 @@ other_commands = {
             'help': 'e.g. "a.domain.name s995 t"',
         },
     ),
+    'drop_peer': (
+        'drop a peer from the peers list',
+        [], {
+            'type': str,
+            'dest': 'host',
+            'help': 'e.g. "a.domain.name"',
+        },
+    ),
     'daemon_url': (
         "replace the daemon's URL at run-time, and forecefully rotate "
         " to the first URL in the list",


### PR DESCRIPTION
Takes a hostname or IP as it appears in the peers list, and simply forgets it. That is, it does not mark it bad, so it can be added again through regular discovery or registration, permitting it verifies properly.