### PR TITLE
Add support for estimation mode in estimatesmartfee

### DIFF
--- a/electrumx/server/daemon.py
+++ b/electrumx/server/daemon.py
@@ -228,12 +228,12 @@ class Daemon(object):
         '''Update our record of the daemon's mempool hashes.'''
         return await self._send_single('getrawmempool')
 
-    async def estimatefee(self, block_count):
+    async def estimatefee(self, block_count, estimate_mode):
         '''Return the fee estimate for the block count.  Units are whole
         currency units per KB, e.g. 0.00000995, or -1 if no estimate
         is available.
         '''
-        args = (block_count, )
+        args = (block_count, estimate_mode)
         if await self._is_rpc_available('estimatesmartfee'):
             estimate = await self._send_single('estimatesmartfee', args)
             return estimate.get('feerate', -1)

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1220,15 +1220,16 @@ class ElectrumX(SessionBase):
         self.bump_cost(1.0)
         return await self.daemon_request('relayfee')
 
-    async def estimatefee(self, number):
+    async def estimatefee(self, number, mode="CONSERVATIVE"):
         '''The estimated transaction fee per kilobyte to be paid for a
         transaction to be included within a certain number of blocks.
 
         number: the number of blocks
+        mode: CONSERVATIVE (default) or ECONOMICAL estimation mode
         '''
         number = non_negative_integer(number)
         self.bump_cost(2.0)
-        return await self.daemon_request('estimatefee', number)
+        return await self.daemon_request('estimatefee', number, mode)
 
     async def ping(self):
         '''Serves as a connection keep-alive mechanism and for the client to


### PR DESCRIPTION
Suggestion to add support for estimation modes in the estimate fee cmd. This would allow for example the Electrum client to implement support for choosing ECONOMICAL or CONSERVATIVE (default) mode. Conservative is often flawed and results in a higher fee suggestion than necessary.

Personally I want ECONOMICAL to be the default but that would be an issue on the Electrum side.

If accepted please review code. Maybe there is a better way of doing this.