### PR TITLE
Support names in "query" RPC command

### DIFF
--- a/docs/rpc-interface.rst
+++ b/docs/rpc-interface.rst
@@ -204,7 +204,8 @@ query
 -----
 
 Run a query of the UTXO and history databases against one or more
-addresses or hex scripts.  `--limit <N>` or `-l <N>` limits the output
+addresses, hex scripts or ASCII names (for coins that have an index
+on names like Namecoin).  `--limit <N>` or `-l <N>` limits the output
 for each kind to that many entries.  History is printed in blockchain
 order; UTXOs in an arbitrary order.
 

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -490,7 +490,7 @@ class SessionManager:
         return self.peer_mgr.rpc_data()
 
     async def rpc_query(self, items, limit):
-        '''Return a list of data about server peers.'''
+        '''Returns data about a script, address or name.'''
         coin = self.env.coin
         db = self.db
         lines = []
@@ -505,11 +505,20 @@ class SessionManager:
 
             try:
                 hashX = coin.address_to_hashX(arg)
-            except Base58Error as e:
-                lines.append(e.args[0])
-                return None
-            lines.append(f'Address: {arg}')
-            return hashX
+                lines.append(f'Address: {arg}')
+                return hashX
+            except Base58Error:
+                pass
+
+            try:
+                script = coin.build_name_index_script(arg.encode("ascii"))
+                hashX = coin.name_hashX_from_script(script)
+                lines.append(f'Name: {arg}')
+                return hashX
+            except (AttributeError, UnicodeEncodeError):
+                pass
+
+            return None
 
         for arg in items:
             hashX = arg_to_hashX(arg)


### PR DESCRIPTION
This extends the `query` RPC command so that it also allows querying for the name index in Namecoin (and potential future coins that support a name index as well).

Previously, that was not possible even when passing the normalised script itself:  In that case, `hashX_from_script` would strip off the name prefix again, and thus the query would only be for `OP_RETURN`.  (Thanks to @JeremyRand for analysing this bug!)