### PR TITLE
Fix setup error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     version=version,
     scripts=['electrumx_server', 'electrumx_rpc', 'electrumx_compact_history'],
     python_requires='>=3.6',
-    install_requires=['aiorpcX[ws]>=0.18.1,<0.19', 'attrs',
+    install_requires=['aiorpcX[ws]>=0.18.3,<0.19', 'attrs',
                       'plyvel', 'pylru', 'aiohttp>=3.3'],
     extras_require={
         'rocksdb': ['python-rocksdb>=0.6.9'],


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2618, in requires
    deps.extend(dm[safe_extra(ext)])
KeyError: 'ws'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    'Topic :: Internet',
  File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/usr/lib/python3/dist-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 437, in run
    self.easy_install(spec, not self.no_deps)
  File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 679, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 726, in install_item
    self.process_distribution(spec, dist, deps)
  File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 771, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 786, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2621, in requires
    "%s has no such extra feature %r" % (self, ext)
pkg_resources.UnknownExtra: aiorpcX 0.18.1 has no such extra feature 'ws'
```