### PR TITLE
add `history.flush_count` to `get_info` rpc response

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -288,6 +288,7 @@ class SessionManager:
             'daemon': self.daemon.logged_url(),
             'daemon height': self.daemon.cached_height(),
             'db height': self.db.db_height,
+            'db_flush_count': self.db.history.flush_count,
             'groups': len(self.session_groups),
             'history cache': cache_fmt.format(
                 self._history_lookups, self._history_hits, len(self._history_cache)),


### PR DESCRIPTION
+ will allow the history flush count to be externally monitored in order to avoid `DB::flush_count overflow` #185 

Not sure about the naming of the json parameter, but feel free to suggest any other existing alternatives if there are any to monitor this value.