### PR TITLE
docs: fix method signature for blockchain.transaction.get

### DIFF
--- a/docs/protocol-methods.rst
+++ b/docs/protocol-methods.rst
@@ -541,7 +541,7 @@ Return a raw transaction.
 
 **Signature**
 
-  .. function:: blockchain.transaction.get(tx_hash, verbose=false, merkle=false)
+  .. function:: blockchain.transaction.get(tx_hash, verbose=false)
   .. versionchanged:: 1.1
      ignored argument *height* removed
   .. versionchanged:: 1.2


### PR DESCRIPTION
The `merkle` arg might be added in a later protocol version but it is not present atm.