### PR TITLE
Enable SegWit support for ODIN

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -2262,6 +2262,7 @@ class Odin(Coin):
 
     SESSIONCLS = DashElectrumX
     DAEMON = daemon.DashDaemon
+    DESERIALIZER = lib_tx.DeserializerSegWit
 
     @classmethod
     def static_header_offset(cls, height):


### PR DESCRIPTION
ODIN Blockchain ($ODIN) recently activated SegWit. This PR adds prope deserialization for special transactions.