### PR TITLE
zelnode transactions for zelcash

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1413,7 +1413,7 @@ class ZelCash(EquihashMixin, Coin):
     P2SH_VERBYTES = [bytes.fromhex("1CBD")]
     GENESIS_HASH = ('00052461a5006c2e3b74ce48992a0869'
                     '5607912d5604c3eb8da25749b0900444')
-    DESERIALIZER = lib_tx.DeserializerZcash
+    DESERIALIZER = lib_tx.DeserializerZelCash
     TX_COUNT = 450539
     TX_COUNT_HEIGHT = 167114
     TX_PER_BLOCK = 3


### PR DESCRIPTION
ZelCash is forking on the 18th of March introducing new deterministic masternodes that come with new on chain transactions. 
Those zelnode transactions are of version 5 and can be of 2 types - start and confirm transaction. 
This PR adds support for those zelnode transactions.