### PR TITLE
Fix travis test(tribus-hash)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install pytest-cov
   - pip install Sphinx
 # hashes
-  - pip install tribus-hash
+  - pip install git+https://github.com/carsenk/tribus-hash
   - pip install blake256
   - pip install scrypt
   - pip install x11_hash


### PR DESCRIPTION
It has disappeared from pypi.
It looks like this repository as far as I look at the cache.
https://github.com/carsenk/tribus-hash

https://webcache.googleusercontent.com/search?q=cache:Pzs11YXBoD0J:https://pypi.org/project/tribus-hash/