### PR TITLE
peer_discovery : Fixing GH link to lib/coins.py

### DIFF
--- a/docs/peer_discovery.rst
+++ b/docs/peer_discovery.rst
@@ -25,7 +25,7 @@ process.  Ideally it should have at least 4 servers that have shown
 commitment to reliable service.
 
 In ElectrumX this is a per-coin property in `lib/coins.py
-<https://github.com/kyuupichan/electrumx/blob/master/lib/coins.py>`_.
+<https://github.com/kyuupichan/electrumx/blob/master/electrumx/lib/coins.py>`_.
 
 
 server.peers.subscribe


### PR DESCRIPTION
Not sure how this remained broken [since 2018](https://github.com/kyuupichan/electrumx/commit/29289004e77eaba1b7e1c951889c5d64ab7ad13c#diff-4bb9e3b2c9b7b43ce48788f676b13068), but here is a simple fix to this link. :-)