### PR TITLE
Update Denarius (D) Tribus pip module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install pytest-cov
   - pip install Sphinx
 # hashes
-  - pip install git+https://github.com/carsenk/tribus-hash
+  - pip install tribushashm
   - pip install blake256
   - pip install scrypt
   - pip install x11_hash

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1916,7 +1916,7 @@ class CanadaeCoin(AuxPowMixin, Coin):
 
 class Denarius(Coin):
     NAME = "Denarius"
-    SHORTNAME = "DNR"
+    SHORTNAME = "D"
     NET = "mainnet"
     XPUB_VERBYTES = bytes.fromhex("0488b21e")
     XPRV_VERBYTES = bytes.fromhex("0488ade4")
@@ -1937,8 +1937,8 @@ class Denarius(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import tribus_hash
-        return tribus_hash.getPoWHash(header)
+        import tribushashm
+        return tribushashm.getPoWHash(header)
 
 
 class DenariusTestnet(Denarius):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         'blake256': ['blake256>=0.1.1'],
         'crypto': ['pycryptodomex>=3.8.1'],
         'groestl': ['groestlcoin-hash>=1.0.1'],
-        'tribus-hash': ['tribus-hash>=1.0.2'],
+        'tribushashm': ['tribushashm>=1.0.5'],
         'xevan-hash': ['xevan-hash'],
         'x11-hash': ['x11-hash>=1.4'],
         'zny-yespower-0-5': ['zny-yespower-0-5'],


### PR DESCRIPTION
This PR updates the Denarius (D) pip module Tribus for the block headers.

The pip module was renamed to tribushashm and version incremented to 1.0.5