### PR TITLE
Add option to deny serving unknown clients

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -281,6 +281,13 @@ These environment variables are optional:
   version string. For example to drop versions from 1.0 to 1.2 use
   the regex ``1\.[0-2]\.\d+``.
 
+.. envvar:: DROP_CLIENT_UNKNOWN
+
+  Set to anything non-empty to deny serving clients, which do not
+  identify themselves first by issuing the server.version method
+  call with a non-empty client identifier. The connection is dropped 
+  on first actual method call. This might help to filter out simple 
+  robots. This behavior is off by default.
 
 Resource Usage Limits
 =====================

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -69,6 +69,7 @@ class Env(EnvBase):
         self.log_level = self.default('LOG_LEVEL', 'info').upper()
         self.donation_address = self.default('DONATION_ADDRESS', '')
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
+        self.drop_client_unknown = self.boolean('DROP_CLIENT_UNKNOWN', False)
         self.cache_MB = self.integer('CACHE_MB', 1200)
         self.reorg_limit = self.integer('REORG_LIMIT', self.coin.REORG_LIMIT)
 

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -885,6 +885,14 @@ class SessionBase(RPCSession):
         else:
             handler = None
         method = 'invalid method' if handler is None else request.method
+
+        # If DROP_CLIENT_UNKNOWN is enabled, check if the client identified
+        # by calling server.version previously. If not, disconnect the session
+        if self.env.drop_client_unknown and method != 'server.version' and self.client == 'unknown':
+            self.logger.info(f'disconnecting because client is unknown')
+            raise ReplyAndDisconnect(
+                BAD_REQUEST, f'use server.version to identify client')
+
         self.session_mgr._method_counts[method] += 1
         coro = handler_invocation(handler, request)()
         return await coro


### PR DESCRIPTION
One can deny serving some specific client versions via DROP_CLIENT. However, there is no way to deny serving clients, which do not identify themselves at all. This patch adds an option to do that. If DROP_CLIENT_UNKNOWN is set, the server will drop connections on a first method call (other than server.version) if the client is unknown.

Let me know what you think. I am running this fork in production myself.