### PR TITLE
Catch random crash when notifying the client

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -991,7 +991,8 @@ class ElectrumX(SessionBase):
                 if changed:
                     es = '' if len(changed) == 1 else 'es'
                     self.logger.info(f'notified of {len(changed):,d} address{es}')
-        except:
+        except Exception as e:
+            self.logger.error(f'Error: {e}')
             self.connection_lost()
 
     async def subscribe_headers_result(self):


### PR DESCRIPTION
Catch for random error when Electrumx wants to notify a client and it fails, causing the ElectrumX to crash, associated with #966 .