### PR TITLE
use requirements.txt in place of a list in setup.py 'install_requires'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+aiorpcX[ws]>=0.18.3,<0.19
+attrs
+plyvel
+pylru
+aiohttp>=3.3

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 import setuptools
 version = '1.15.0'
 
+with open('requirements.txt', 'r') as f:
+    requirements = f.read().splitlines()
+
 setuptools.setup(
     name='electrumX',
     version=version,
     scripts=['electrumx_server', 'electrumx_rpc', 'electrumx_compact_history'],
     python_requires='>=3.7',
-    install_requires=['aiorpcX[ws]>=0.18.3,<0.19', 'attrs',
-                      'plyvel', 'pylru', 'aiohttp>=3.3'],
+    install_requires=requirements,
     extras_require={
         'rocksdb': ['python-rocksdb>=0.6.9'],
         'uvloop': ['uvloop>=0.14'],


### PR DESCRIPTION
- makes shell scripting easier for electrumsv-sdk to workaround issues on windows with installing plyvel
