### PR TITLE
Fix typo in LTORBlockProcessor::backup_txs

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -832,7 +832,7 @@ class LTORBlockProcessor(BlockProcessor):
                     continue
 
                 # Get the hashX
-                hashX = script_hashX(txout.script)
+                hashX = script_hashX(txout.pk_script)
                 cache_value = spend_utxo(tx_hash, idx)
                 add_touched(cache_value[:-13])
 


### PR DESCRIPTION
I'm not entirely sure what triggers this code; but I caught it failing.  Dumping the object confirmed it was an instance of `TxOutput`, and that the line in question would always fail.  Fixing the bad attribute name seemed to fix things. 