### PR TITLE
Pass `reuse_address` into asyncio for the listen socket. This is alre…

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -178,7 +178,7 @@ class SessionManager:
             host = None if service.host == 'all_interfaces' else str(service.host)
             try:
                 self.servers[service] = await serve(session_factory, host,
-                                                    service.port, ssl=sslc)
+                                                    service.port, ssl=sslc, reuse_address=True)
             except OSError as e:    # don't suppress CancelledError
                 self.logger.error(f'{kind} server failed to listen on {service.address}: {e}')
             else:


### PR DESCRIPTION
…ady enabled by default on posix systems by asyncio, and this change now enables it on other systems or really Windows. It is a needlesss step to have to wait for the `TIME_WAIT` state to clear for a socket only used by one thing.