### PR TITLE
Remove pytest call in storage.py

### DIFF
--- a/electrumx/server/storage.py
+++ b/electrumx/server/storage.py
@@ -10,15 +10,11 @@
 import os
 from functools import partial
 
-import pytest
 from electrumx.lib import util
 
 
 def db_class(name):
     '''Returns a DB engine class.'''
-    if name == "skip":
-        raise pytest.skip()
-
     for db_class_ in util.subclasses(Storage):
         if db_class_.__name__.lower() == name.lower():
             db_class_.import_module()

--- a/tests/server/test_storage.py
+++ b/tests/server/test_storage.py
@@ -20,6 +20,8 @@ for klass in subclasses(Storage):
 def db(tmpdir, request):
     cwd = os.getcwd()
     os.chdir(str(tmpdir))
+    if request.param is 'skip':
+        raise pytest.skip()
     db = db_class(request.param)("db", False)
     yield db
     os.chdir(cwd)


### PR DESCRIPTION
Sorry for this. I hadn't realised that my earlier commit was importing pytest in the main code. I thought db_class(name) was test code at the time.. This removes the pytest import (otherwise it would need to be added to the requirements.txt file)